### PR TITLE
fix docs corresponding with rename in d07c22ec

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -59,9 +59,9 @@ The build steps include:
 
 1) Build wxWidgets 2.8 compoents. cd to wxwidgets-2.8/build_gtk, ./run_configure.sh, and then make
 
-2) Build snap components (cd unix, make)
+2) Build snap components (cd linux, make)
 
-3) Copy unix/release/install to a suitable system directory, or add this directory
+3) Copy linux/release/install to a suitable system directory, or add this directory
    to the PATH environment variable.
 
 


### PR DESCRIPTION
The unix directory was renamed in d07c22ec6a87269fc296f19c37784af7eb2d5fef. This updates the documentation to reflect this