### PR TITLE
Adding optional csv file catalogue

### DIFF
--- a/ms/projects/snaplib/snaplib.vcxproj
+++ b/ms/projects/snaplib/snaplib.vcxproj
@@ -205,6 +205,7 @@
     <ClCompile Include="..\..\..\src\snaplib\util\dms.c" />
     <ClCompile Include="..\..\..\src\snaplib\util\dstring.c" />
     <ClCompile Include="..\..\..\src\snaplib\util\errdef.c" />
+    <ClCompile Include="..\..\..\src\snaplib\util\filelist.c" />
     <ClCompile Include="..\..\..\src\snaplib\util\fileutil.c" />
     <ClCompile Include="..\..\..\src\snaplib\util\geodetic.c" />
     <ClCompile Include="..\..\..\src\snaplib\util\getversion.c" />
@@ -303,6 +304,7 @@
     <ClInclude Include="..\..\..\src\snaplib\util\dms.h" />
     <ClInclude Include="..\..\..\src\snaplib\util\dstring.h" />
     <ClInclude Include="..\..\..\src\snaplib\util\errdef.h" />
+    <ClInclude Include="..\..\..\src\snaplib\util\filelist.h" />
     <ClInclude Include="..\..\..\src\snaplib\util\fileutil.h" />
     <ClInclude Include="..\..\..\src\snaplib\util\geodetic.h" />
     <ClInclude Include="..\..\..\src\snaplib\util\get_date.h" />

--- a/ms/projects/snaplib/snaplib.vcxproj.filters
+++ b/ms/projects/snaplib/snaplib.vcxproj.filters
@@ -331,6 +331,9 @@
     <ClCompile Include="..\..\..\src\snaplib\util\errdef.c">
       <Filter>Source Files\util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\src\snaplib\util\filelist.c">
+      <Filter>Source Files\util</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\..\src\snaplib\util\fileutil.c">
       <Filter>Source Files\util</Filter>
     </ClCompile>
@@ -652,6 +655,9 @@
       <Filter>Header Files\util</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\snaplib\util\errdef.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\src\snaplib\util\filelist.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\src\snaplib\util\fileutil.h">

--- a/regression_tests/runtests.pl
+++ b/regression_tests/runtests.pl
@@ -7,7 +7,7 @@ use Cwd qw(cwd abs_path);
 use File::Find;
 use File::Path qw(make_path remove_tree);
 use File::Basename;
-use File::Copy;
+use File::Copy "cp";
 
 my $syntax=<<EOD;
 
@@ -304,7 +304,7 @@ foreach my $test (sort keys %tests)
         }
         my $odir=dirname($tgt);
         make_path($odir) if ! -d $odir;
-        copy($src,$tgt);
+        cp($src,$tgt);
         $inputfiles{$tgt}=1 if $save eq '';
     }
     die "Cannot run test - files missing\n" if $missing > 0;
@@ -364,7 +364,7 @@ foreach my $test (sort keys %tests)
             my $ofile="$tstout/$fn";
             my $odir=dirname($ofile);
             make_path($odir) if ! -d $odir;
-            copy($_,$ofile);
+            cp($_,$ofile);
             print "Saving output file $ofile\n" if $verbose;
         },
         no_chdir=>1},

--- a/regression_tests/snap/check/test1/test1-filelist.csv
+++ b/regression_tests/snap/check/test1/test1-filelist.csv
@@ -1,0 +1,13 @@
+"id","filename","filetype","filedate","filesize"
+0,"/home/ccrook/projects_git/snap/regression_tests/snap/../test_coordsys/coordsys.def","coordinate systems definition","2018-06-28 09:02:46",55561
+1,"test1.lst","listing","2018-08-15 08:44:09",199925
+2,"test1.snp","command","2018-08-15 08:44:09",959
+3,"test1.crd","station coordinate file","2018-08-15 08:44:09",625
+4,"test1.bin","snap_binary_file","2018-08-15 08:44:09",52658
+5,"test1.dat","survey data file","2018-08-15 08:44:09",9485
+6,"test1a.dat","survey data file","2018-08-15 08:44:09",1489
+7,"test1-stn.csv","stn_output_csv","2018-08-15 08:44:09",776
+8,"test1-obs.csv","obs_output_csv","2018-08-15 08:44:09",40516
+9,"test1-metadata.csv","metadata_output_csv","2018-08-15 08:44:09",827
+10,"test1.new","output_station_coordinate_file","2018-08-15 08:44:09",690
+11,"test1-filelist.csv","filelist_output_csv","2018-08-15 08:44:09",0

--- a/regression_tests/snap/check/test1/test1-filelist.csv
+++ b/regression_tests/snap/check/test1/test1-filelist.csv
@@ -1,13 +1,13 @@
 "id","filename","filetype","filedate","filesize"
-0,"/home/ccrook/projects_git/snap/regression_tests/snap/../test_coordsys/coordsys.def","coordinate systems definition","2018-06-28 09:02:46",55561
-1,"test1.lst","listing","2018-08-15 08:44:09",199925
-2,"test1.snp","command","2018-08-15 08:44:09",959
-3,"test1.crd","station coordinate file","2018-08-15 08:44:09",625
-4,"test1.bin","snap_binary_file","2018-08-15 08:44:09",52658
-5,"test1.dat","survey data file","2018-08-15 08:44:09",9485
-6,"test1a.dat","survey data file","2018-08-15 08:44:09",1489
-7,"test1-stn.csv","stn_output_csv","2018-08-15 08:44:09",776
-8,"test1-obs.csv","obs_output_csv","2018-08-15 08:44:09",40516
-9,"test1-metadata.csv","metadata_output_csv","2018-08-15 08:44:09",827
-10,"test1.new","output_station_coordinate_file","2018-08-15 08:44:09",690
-11,"test1-filelist.csv","filelist_output_csv","2018-08-15 08:44:09",0
+0,"/home/ccrook/projects_git/snap/regression_tests/snap/../test_coordsys/coordsys.def","coordinate_systems_definition","2018-06-28 09:02:46",55561
+1,"test1.lst","listing","2018-08-15 13:21:21",199925
+2,"test1.snp","command","2018-08-15 13:21:21",959
+3,"test1.crd","station_coordinate","2018-08-15 13:21:21",625
+4,"test1.bin","snap_binary","2018-08-15 13:21:21",52658
+5,"test1.dat","survey_data","2018-08-15 13:21:21",9485
+6,"test1a.dat","survey_data","2018-08-15 13:21:21",1489
+7,"test1-stn.csv","stn_output_csv","2018-08-15 13:21:21",776
+8,"test1-obs.csv","obs_output_csv","2018-08-15 13:21:21",40516
+9,"test1-metadata.csv","metadata_output_csv","2018-08-15 13:21:21",827
+10,"test1.new","output_station_coordinate","2018-08-15 13:21:21",690
+11,"test1-filelist.csv","filelist_output_csv","2018-08-15 13:21:21",0

--- a/regression_tests/snap/check/test1/test1-metadata.csv
+++ b/regression_tests/snap/check/test1/test1-metadata.csv
@@ -1,6 +1,6 @@
 "code","value","comment"
-"SNAPVER","2.7.11-d9d53f6","SNAP version"
-"RUNTIME","15-AUG-2018 08:44:09","Run time"
+"SNAPVER","2.7.11-2620383","SNAP version"
+"RUNTIME","15-AUG-2018 13:21:21","Run time"
 "TITLE","Regression test 1 - data types and observation equations","Job title"
 "CRDSYS","NZGD1949","New Zealand Geodetic Datum 1949"
 "NOBS",167,"Number of observations"

--- a/regression_tests/snap/check/test1/test1-metadata.csv
+++ b/regression_tests/snap/check/test1/test1-metadata.csv
@@ -1,6 +1,6 @@
 "code","value","comment"
-"SNAPVER","2.7.10-bf63ac3","SNAP version"
-"RUNTIME","13-AUG-2018 13:42:14","Run time"
+"SNAPVER","2.7.11-d9d53f6","SNAP version"
+"RUNTIME","15-AUG-2018 08:44:09","Run time"
 "TITLE","Regression test 1 - data types and observation equations","Job title"
 "CRDSYS","NZGD1949","New Zealand Geodetic Datum 1949"
 "NOBS",167,"Number of observations"

--- a/regression_tests/snap/check/test1/test1.lst
+++ b/regression_tests/snap/check/test1/test1.lst
@@ -1,15 +1,15 @@
 ================================================================================
 
-                      PROGRAM SNAP  Version 2.7.10-bf63ac3
+                      PROGRAM SNAP  Version 2.7.11-d9d53f6
 
                        Survey Network Adjustment Program
 
                     Copyright: Land Information New Zealand
                               Author: Chris Crook
-                       Version date: Aug 13 2018 13:11:29
+                       Version date: Aug 15 2018 08:42:14
 
 ================================================================================
-                     Run at 13-AUG-2018 13:42:14 by ccrook
+                     Run at 15-AUG-2018 08:44:09 by ccrook
 
 
 The command file test1.snp contains:
@@ -36,7 +36,7 @@ The command file test1.snp contains:
      list error_summary
      list worst_residuals
      
-     output_csv metadata stations observations wkt_shape vector_components correlations
+     output_csv metadata stations observations wkt_shape vector_components correlations filelist
      
      ! error_type aposteriori
      
@@ -56,7 +56,7 @@ The command file test1.snp contains:
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                              SUMMARY OF INPUT FILES
 
@@ -113,7 +113,7 @@ Data file 2: test1a.dat
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                                    INPUT DATA
 
@@ -3405,7 +3405,7 @@ END_JSON observations
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                              DEFINITION OF PROBLEM
 
@@ -3429,7 +3429,7 @@ Station  Adj  Row  Name
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                              OBSERVATION EQUATIONS
 
@@ -6368,7 +6368,7 @@ END_JSON obs_equation_1
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                                 SOLUTION SUMMARY
 
@@ -6392,7 +6392,7 @@ You may have over-estimated the errors of the data.
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                               STATION COORDINATES
 
@@ -6433,7 +6433,7 @@ Rejected stations are flagged #
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                            REFERENCE FRAME PARAMETERS
 
@@ -6459,7 +6459,7 @@ Reference frame: GPS
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                                 OTHER PARAMETERS
 
@@ -6474,7 +6474,7 @@ Refr coef DEFAULT                    0.00000       -
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                              OBSERVATION RESIDUALS
 
@@ -6987,7 +6987,7 @@ File test1a.dat: line 118
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                                  ERROR SUMMARY
 
@@ -7448,7 +7448,7 @@ longitude                                   0.00    6    0.00    2    0.00    8
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    13-AUG-2018 13:42:14
+Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
 
                            MOST SIGNIFICANT RESIDUALS
 

--- a/regression_tests/snap/check/test1/test1.lst
+++ b/regression_tests/snap/check/test1/test1.lst
@@ -1,15 +1,15 @@
 ================================================================================
 
-                      PROGRAM SNAP  Version 2.7.11-d9d53f6
+                      PROGRAM SNAP  Version 2.7.11-2620383
 
                        Survey Network Adjustment Program
 
                     Copyright: Land Information New Zealand
                               Author: Chris Crook
-                       Version date: Aug 15 2018 08:42:14
+                       Version date: Aug 15 2018 13:11:52
 
 ================================================================================
-                     Run at 15-AUG-2018 08:44:09 by ccrook
+                     Run at 15-AUG-2018 13:21:21 by ccrook
 
 
 The command file test1.snp contains:
@@ -56,7 +56,7 @@ The command file test1.snp contains:
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                              SUMMARY OF INPUT FILES
 
@@ -113,7 +113,7 @@ Data file 2: test1a.dat
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                                    INPUT DATA
 
@@ -3405,7 +3405,7 @@ END_JSON observations
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                              DEFINITION OF PROBLEM
 
@@ -3429,7 +3429,7 @@ Station  Adj  Row  Name
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                              OBSERVATION EQUATIONS
 
@@ -6368,7 +6368,7 @@ END_JSON obs_equation_1
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                                 SOLUTION SUMMARY
 
@@ -6392,7 +6392,7 @@ You may have over-estimated the errors of the data.
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                               STATION COORDINATES
 
@@ -6433,7 +6433,7 @@ Rejected stations are flagged #
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                            REFERENCE FRAME PARAMETERS
 
@@ -6459,7 +6459,7 @@ Reference frame: GPS
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                                 OTHER PARAMETERS
 
@@ -6474,7 +6474,7 @@ Refr coef DEFAULT                    0.00000       -
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                              OBSERVATION RESIDUALS
 
@@ -6987,7 +6987,7 @@ File test1a.dat: line 118
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                                  ERROR SUMMARY
 
@@ -7448,7 +7448,7 @@ longitude                                   0.00    6    0.00    2    0.00    8
 
 
 ================================================================================
-Regression test 1 - data types and observation equations    15-AUG-2018 08:44:09
+Regression test 1 - data types and observation equations    15-AUG-2018 13:21:21
 
                            MOST SIGNIFICANT RESIDUALS
 

--- a/regression_tests/snap/check/test1/test1.new
+++ b/regression_tests/snap/check/test1/test1.new
@@ -1,7 +1,7 @@
 Test 1 - basic obs type tests
 NZGD1949
 options ellipsoidal_heights no_deflections geoid_heights c=Order c=Mark_Type
-! Updated by SNAP version 2.7.10-bf63ac3 at 13-AUG-2018 13:42:14
+! Updated by SNAP version 2.7.11-d9d53f6 at 15-AUG-2018 08:44:09
 
 !Code       Latitude          Longitude        Ell.Hgt   G.Hgt Order Mark_Type Name
 1      41 00 46.800000 S 173 19 15.600000 E   150.0000  0.0000 2     PIN   Node one

--- a/regression_tests/snap/check/test1/test1.new
+++ b/regression_tests/snap/check/test1/test1.new
@@ -1,7 +1,7 @@
 Test 1 - basic obs type tests
 NZGD1949
 options ellipsoidal_heights no_deflections geoid_heights c=Order c=Mark_Type
-! Updated by SNAP version 2.7.11-d9d53f6 at 15-AUG-2018 08:44:09
+! Updated by SNAP version 2.7.11-2620383 at 15-AUG-2018 13:21:21
 
 !Code       Latitude          Longitude        Ell.Hgt   G.Hgt Order Mark_Type Name
 1      41 00 46.800000 S 173 19 15.600000 E   150.0000  0.0000 2     PIN   Node one

--- a/regression_tests/snap/check/test1csv/test1csv-filelist.csv
+++ b/regression_tests/snap/check/test1csv/test1csv-filelist.csv
@@ -1,0 +1,14 @@
+"id","filename","filetype","filedate","filesize"
+0,"/home/ccrook/projects_git/snap/regression_tests/snap/../test_coordsys/coordsys.def","coordinate_systems_definition","2018-06-28 09:02:46",55561
+1,"test1csv.lst","listing","2018-08-15 13:21:21",138784
+2,"test1csv.snp","command","2018-08-15 13:21:21",620
+3,"teststn.csv","station_coordinate","2018-08-15 13:21:21",782
+4,"/home/ccrook/projects_git/snap/linux/debug/install/config/format/stn.dtf","csv_station_format","2016-11-18 05:33:30",542
+5,"test1csv.bin","snap_binary","2018-08-15 13:21:21",41600
+6,"testobs.csv","survey_data","2018-08-15 13:21:21",29404
+7,"obs.dtf","csv_obs_format","2018-08-15 13:21:21",621
+8,"test1csv-stn.csv","stn_output_csv","2018-08-15 13:21:21",776
+9,"test1csv-obs.csv","obs_output_csv","2018-08-15 13:21:21",31327
+10,"test1csv-metadata.csv","metadata_output_csv","2018-08-15 13:21:21",816
+11,"teststn.new","output_station_coordinate","2018-08-15 13:21:21",690
+12,"test1csv-filelist.csv","filelist_output_csv","2018-08-15 13:21:21",0

--- a/regression_tests/snap/check/test1csv/test1csv-metadata.csv
+++ b/regression_tests/snap/check/test1csv/test1csv-metadata.csv
@@ -1,6 +1,6 @@
 "code","value","comment"
-"SNAPVER","2.7.10-bf63ac3","SNAP version"
-"RUNTIME","13-AUG-2018 13:42:14","Run time"
+"SNAPVER","2.7.11-2620383","SNAP version"
+"RUNTIME","15-AUG-2018 13:21:21","Run time"
 "TITLE","Regression test 1csv - CSV format data/coords","Job title"
 "CRDSYS","NZGD1949","New Zealand Geodetic Datum 1949"
 "NOBS",127,"Number of observations"

--- a/regression_tests/snap/check/test1csv/test1csv.lst
+++ b/regression_tests/snap/check/test1csv/test1csv.lst
@@ -1,15 +1,15 @@
 ================================================================================
 
-                      PROGRAM SNAP  Version 2.7.10-bf63ac3
+                      PROGRAM SNAP  Version 2.7.11-2620383
 
                        Survey Network Adjustment Program
 
                     Copyright: Land Information New Zealand
                               Author: Chris Crook
-                       Version date: Aug 13 2018 13:11:29
+                       Version date: Aug 15 2018 13:11:52
 
 ================================================================================
-                     Run at 13-AUG-2018 13:42:14 by ccrook
+                     Run at 15-AUG-2018 13:21:21 by ccrook
 
 
 The command file test1csv.snp contains:
@@ -34,7 +34,7 @@ The command file test1csv.snp contains:
      list error_summary
      list worst_residuals
      
-     output_csv metadata stations observations wkt_shape vector_components correlations
+     output_csv filelist metadata stations observations wkt_shape vector_components correlations
      
      ! error_type aposteriori
      
@@ -46,7 +46,7 @@ The command file test1csv.snp contains:
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                              SUMMARY OF INPUT FILES
 
@@ -87,7 +87,7 @@ Data file 1: testobs.csv
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                                    INPUT DATA
 
@@ -2687,7 +2687,7 @@ END_JSON observations
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                              DEFINITION OF PROBLEM
 
@@ -2711,7 +2711,7 @@ Station  Adj  Row  Name
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                              OBSERVATION EQUATIONS
 
@@ -5118,7 +5118,7 @@ END_JSON obs_equation_1
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                                 SOLUTION SUMMARY
 
@@ -5142,7 +5142,7 @@ You may have over-estimated the errors of the data.
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                               STATION COORDINATES
 
@@ -5183,7 +5183,7 @@ Rejected stations are flagged #
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                            REFERENCE FRAME PARAMETERS
 
@@ -5209,7 +5209,7 @@ Reference frame: GPS
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                                 OTHER PARAMETERS
 
@@ -5224,7 +5224,7 @@ Refr coef DEFAULT                    0.00000       -
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                              OBSERVATION RESIDUALS
 
@@ -5647,7 +5647,7 @@ File testobs.csv: line 108
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                                  ERROR SUMMARY
 
@@ -5702,7 +5702,7 @@ longitude                                   0.00    4    0.00    2    0.00    6
 
 
 ================================================================================
-Regression test 1csv - CSV format data/coords               13-AUG-2018 13:42:14
+Regression test 1csv - CSV format data/coords               15-AUG-2018 13:21:21
 
                            MOST SIGNIFICANT RESIDUALS
 

--- a/regression_tests/snap/check/test1csv/teststn.new
+++ b/regression_tests/snap/check/test1csv/teststn.new
@@ -1,7 +1,7 @@
 Read from teststn.csv
 NZGD1949
 options ellipsoidal_heights no_deflections geoid_heights degrees c=Order c=Mark_Type
-! Updated by SNAP version 2.7.10-bf63ac3 at 13-AUG-2018 13:42:14
+! Updated by SNAP version 2.7.11-2620383 at 15-AUG-2018 13:21:21
 
 !Code       Latitude          Longitude        Ell.Hgt   G.Hgt Order Mark_Type Name
 1        -41.01300000000    173.32100000000   150.0000  0.0000 2     PIN   Node one

--- a/regression_tests/snap/check/testsnx1/testsnx1-filelist.csv
+++ b/regression_tests/snap/check/testsnx1/testsnx1-filelist.csv
@@ -1,0 +1,9 @@
+"id","filename","filetype","filedate","filesize"
+0,"/home/ccrook/projects_git/snap/regression_tests/snap/../test_coordsys/coordsys.def","coordinate_systems_definition","2018-06-28 09:02:46",55561
+1,"testsnx1.lst","listing","2018-08-15 13:21:22",45642
+2,"testsnx1.snp","command","2018-08-15 13:21:22",269
+3,"testsnx1.crd","station_coordinate","2018-08-15 13:21:22",1544
+4,"testsnx1.bin","snap_binary","2018-08-15 13:21:22",99854
+5,"testsnx1.in.snx","survey_data","2018-08-15 13:21:22",73386
+6,"testsnx1.new","output_station_coordinate","2018-08-15 13:21:22",1609
+7,"testsnx1-filelist.csv","filelist_output_csv","2018-08-15 13:21:22",0

--- a/regression_tests/snap/check/testsnx1/testsnx1.err
+++ b/regression_tests/snap/check/testsnx1/testsnx1.err
@@ -1,21 +1,21 @@
 ================================================================================
 
-                      PROGRAM SNAP  Version 2.7.10-bf63ac3
+                      PROGRAM SNAP  Version 2.7.11-2620383
 
                        Survey Network Adjustment Program
 
                     Copyright: Land Information New Zealand
                               Author: Chris Crook
-                       Version date: Aug 13 2018 13:11:29
+                       Version date: Aug 15 2018 13:11:52
 
 ================================================================================
-                     Run at 13-AUG-2018 13:42:14 by ccrook
+                     Run at 15-AUG-2018 13:21:22 by ccrook
 
 
 
 
 ================================================================================
-                                                            13-AUG-2018 13:42:14
+                                                            15-AUG-2018 13:21:22
 
                                  ERROR SUMMARY
 

--- a/regression_tests/snap/check/testsnx1/testsnx1.lst
+++ b/regression_tests/snap/check/testsnx1/testsnx1.lst
@@ -1,15 +1,15 @@
 ================================================================================
 
-                      PROGRAM SNAP  Version 2.7.10-bf63ac3
+                      PROGRAM SNAP  Version 2.7.11-2620383
 
                        Survey Network Adjustment Program
 
                     Copyright: Land Information New Zealand
                               Author: Chris Crook
-                       Version date: Aug 13 2018 13:11:29
+                       Version date: Aug 15 2018 13:11:52
 
 ================================================================================
-                     Run at 13-AUG-2018 13:42:14 by ccrook
+                     Run at 15-AUG-2018 13:21:22 by ccrook
 
 
 
@@ -38,7 +38,7 @@ Errors of the following observations are scaled by 2.000
 
 
 ================================================================================
-Testing SINEX file reading                                  13-AUG-2018 13:42:14
+Testing SINEX file reading                                  15-AUG-2018 13:21:22
 
                                    INPUT DATA
 
@@ -506,7 +506,7 @@ END_JSON observations
 
 
 ================================================================================
-Testing SINEX file reading                                  13-AUG-2018 13:42:14
+Testing SINEX file reading                                  15-AUG-2018 13:21:22
 
                                 SOLUTION SUMMARY
 
@@ -529,7 +529,7 @@ You may have over-estimated the errors of the data.
 
 
 ================================================================================
-Testing SINEX file reading                                  13-AUG-2018 13:42:14
+Testing SINEX file reading                                  15-AUG-2018 13:21:22
 
                               STATION COORDINATES
 
@@ -618,7 +618,7 @@ Rejected stations are flagged #
 
 
 ================================================================================
-Testing SINEX file reading                                  13-AUG-2018 13:42:14
+Testing SINEX file reading                                  15-AUG-2018 13:21:22
 
                            REFERENCE FRAME PARAMETERS
 
@@ -659,7 +659,7 @@ Reference frame: QRF
 
 
 ================================================================================
-Testing SINEX file reading                                  13-AUG-2018 13:42:14
+Testing SINEX file reading                                  15-AUG-2018 13:21:22
 
                              OBSERVATION RESIDUALS
 
@@ -775,7 +775,7 @@ KARR_A GX    -2713832.3708  0.0119  -2713832.3709  0.0000  0.0000  0.0097   0.00
 
 
 ================================================================================
-Testing SINEX file reading                                  13-AUG-2018 13:42:14
+Testing SINEX file reading                                  15-AUG-2018 13:21:22
 
                                  ERROR SUMMARY
 
@@ -809,7 +809,7 @@ testsnx1.in.snx                             0.01   15     -      -    0.01   15
 
 
 ================================================================================
-Testing SINEX file reading                                  13-AUG-2018 13:42:14
+Testing SINEX file reading                                  15-AUG-2018 13:21:22
 
                            MOST SIGNIFICANT RESIDUALS
 
@@ -852,7 +852,7 @@ HOKI             GX     0.015    0.001        187  testsnx1.in.snx
 
 
 ================================================================================
-Testing SINEX file reading                                  13-AUG-2018 13:42:14
+Testing SINEX file reading                                  15-AUG-2018 13:21:22
 
                                      ERRORS
 

--- a/regression_tests/snap/check/testsnx1/testsnx1.new
+++ b/regression_tests/snap/check/testsnx1/testsnx1.new
@@ -1,7 +1,7 @@
 Testing SINEX file reading
 ITRF96
 options orthometric_heights deflections geoid_heights
-! Updated by SNAP version 2.7.10-bf63ac3 at 13-AUG-2018 13:42:14
+! Updated by SNAP version 2.7.11-2620383 at 15-AUG-2018 13:21:22
 
 !Code       Latitude          Longitude       Orth.Hgt    Xi   Eta   G.Hgt Name
 5503   43 57 22.583212 S 176 33 57.088068 W    59.0830   0.0   0.0  0.0000 5503

--- a/regression_tests/snap/check/testsr8/testsr8.lst
+++ b/regression_tests/snap/check/testsr8/testsr8.lst
@@ -1,15 +1,15 @@
 ================================================================================
 
-                      PROGRAM SNAP  Version 2.7.10-bf63ac3
+                      PROGRAM SNAP  Version 2.7.11-50bef96
 
                        Survey Network Adjustment Program
 
                     Copyright: Land Information New Zealand
                               Author: Chris Crook
-                       Version date: Aug 13 2018 13:11:29
+                       Version date: Aug 15 2018 12:45:50
 
 ================================================================================
-                     Run at 13-AUG-2018 13:42:14 by ccrook
+                     Run at 15-AUG-2018 12:48:19 by ccrook
 
 
 The command file testsr8.snp contains:
@@ -44,7 +44,7 @@ The command file testsr8.snp contains:
 
 
 ================================================================================
-Regression tests - calc recode with errors                  13-AUG-2018 13:42:14
+Regression tests - calc recode with errors                  15-AUG-2018 12:48:19
 
                              SUMMARY OF INPUT FILES
 
@@ -71,7 +71,7 @@ Data file 1: testsr8.dat
 
 
 ================================================================================
-Regression tests - calc recode with errors                  13-AUG-2018 13:42:14
+Regression tests - calc recode with errors                  15-AUG-2018 12:48:19
 
                                 RECODED STATIONS
 
@@ -85,7 +85,7 @@ The following stations are being recoded as they are read from data files
 
 
 ================================================================================
-Regression tests - calc recode with errors                  13-AUG-2018 13:42:14
+Regression tests - calc recode with errors                  15-AUG-2018 12:48:19
 
                              DEFINITION OF PROBLEM
 
@@ -137,7 +137,7 @@ LINZ deformation model
 
 
 ================================================================================
-Regression tests - calc recode with errors                  13-AUG-2018 13:42:14
+Regression tests - calc recode with errors                  15-AUG-2018 12:48:19
 
                               STATION COORDINATES
 
@@ -203,7 +203,7 @@ Rejected stations are flagged #
 
 
 ================================================================================
-Regression tests - calc recode with errors                  13-AUG-2018 13:42:14
+Regression tests - calc recode with errors                  15-AUG-2018 12:48:19
 
                                 FLOATED STATIONS
 
@@ -218,14 +218,14 @@ Significance is based on the Normal distribution function
 
 Code  rel    coord      error      calc.err    residual    adj.err    std.res
 
-1_1   1       East       0.1000      0.1000     -0.0000        -nan      -
+1_1   1       East       0.1000      0.1000     -0.0000      0.0000      -
               North      0.1000      0.1000     -0.0000      0.0000      -
-              Up         0.3000      0.3000     -0.0000        -nan      -
+              Up         0.3000      0.3000     -0.0000      0.0000      -
 
 
 
 ================================================================================
-Regression tests - calc recode with errors                  13-AUG-2018 13:42:14
+Regression tests - calc recode with errors                  15-AUG-2018 12:48:19
 
                              OBSERVATION RESIDUALS
 

--- a/regression_tests/snap/check/testsr8/testsr8.new
+++ b/regression_tests/snap/check/testsr8/testsr8.new
@@ -1,7 +1,7 @@
 Test 1 - basic obs type tests
 NZGD2000(20160701)
 options ellipsoidal_heights no_deflections no_geoid_heights degrees c=Order c=Mark_Type
-! Updated by SNAP version 2.7.10-bf63ac3 at 13-AUG-2018 13:42:14
+! Updated by SNAP version 2.7.11-50bef96 at 15-AUG-2018 12:48:19
 
 !Code       Latitude          Longitude        Ell.Hgt Order Mark_Type Name
 1        -41.00199995034    173.32640006169   165.0993 2     PIN   1 PIN

--- a/regression_tests/snap/in/test1.snp
+++ b/regression_tests/snap/in/test1.snp
@@ -21,7 +21,7 @@ list residuals
 list error_summary
 list worst_residuals
 
-output_csv metadata stations observations wkt_shape vector_components correlations
+output_csv metadata stations observations wkt_shape vector_components correlations filelist
 
 ! error_type aposteriori
 

--- a/regression_tests/snap/in/test1csv.snp
+++ b/regression_tests/snap/in/test1csv.snp
@@ -19,7 +19,7 @@ list residuals
 list error_summary
 list worst_residuals
 
-output_csv metadata stations observations wkt_shape vector_components correlations
+output_csv filelist metadata stations observations wkt_shape vector_components correlations
 
 ! error_type aposteriori
 

--- a/regression_tests/snap/in/testsnx1.snp
+++ b/regression_tests/snap/in/testsnx1.snp
@@ -8,3 +8,4 @@ data_file testsnx1.in.snx SINEX ref_frame=QRF code=POINT date=1MAY2013 error_fac
 ignore_missing_stations yes
 
 list input_data
+output_csv filelist

--- a/regression_tests/snap/test.config
+++ b/regression_tests/snap/test.config
@@ -58,8 +58,8 @@ match_replace_re: ~\.(lst|err)$  ~\\  ~\/
 match_replace_re: ~metadata\.csv$  ~^(\"RUNTIME\"\,).*   ~$1,00:00:00
 match_replace_re: ~metadata\.csv$  ~^(\"SNAPVER\"\,).*   ~$1,0.0.0
 match_replace_re: ~filelist\.csv$  ~\,\"2\d\d\d\-\d\d\-\d\d\s\d\d\:\d\d\:\d\d\"\,\d+ ~,"2000-01-01",0
-match_replace_re: ~filelist\.csv$  ~\".*test_coordsys ~,"test_coordsys
-
+match_replace_re: ~filelist\.csv$  ~\".*\/test_coordsys\/ ~"test_coordsys/
+match_replace_re: ~filelist\.csv$  ~\".*\/config\/ ~"config/
 
 match_replace_re: ~\.(newcrd|new)   ~^(\! Updated by SNAP ).*   ~$1...
 

--- a/regression_tests/snap/test.config
+++ b/regression_tests/snap/test.config
@@ -57,6 +57,8 @@ match_replace_re: ~\.(lst|err)$  ~\\  ~\/
 
 match_replace_re: ~metadata\.csv$  ~^(\"RUNTIME\"\,).*   ~$1,00:00:00
 match_replace_re: ~metadata\.csv$  ~^(\"SNAPVER\"\,).*   ~$1,0.0.0
+match_replace_re: ~filelist\.csv$  ~\,\"2\d\d\d\-\d\d\-\d\d\s\d\d\:\d\d\:\d\d\"\, ~,"2000-01-01",
+
 
 match_replace_re: ~\.(newcrd|new)   ~^(\! Updated by SNAP ).*   ~$1...
 

--- a/regression_tests/snap/test.config
+++ b/regression_tests/snap/test.config
@@ -57,7 +57,8 @@ match_replace_re: ~\.(lst|err)$  ~\\  ~\/
 
 match_replace_re: ~metadata\.csv$  ~^(\"RUNTIME\"\,).*   ~$1,00:00:00
 match_replace_re: ~metadata\.csv$  ~^(\"SNAPVER\"\,).*   ~$1,0.0.0
-match_replace_re: ~filelist\.csv$  ~\,\"2\d\d\d\-\d\d\-\d\d\s\d\d\:\d\d\:\d\d\"\, ~,"2000-01-01",
+match_replace_re: ~filelist\.csv$  ~\,\"2\d\d\d\-\d\d\-\d\d\s\d\d\:\d\d\:\d\d\"\,\d+ ~,"2000-01-01",0
+match_replace_re: ~filelist\.csv$  ~\".*test_coordsys ~,"test_coordsys
 
 
 match_replace_re: ~\.(newcrd|new)   ~^(\! Updated by SNAP ).*   ~$1...

--- a/src/dat2site/dat2site.c
+++ b/src/dat2site/dat2site.c
@@ -3048,6 +3048,7 @@ int main( int argc, char *argv[] )
     char **recalclist;
     char *outputfile = NULL;
 
+    CONFIGURE_RUNTIME();
 
     errcount = 0;
     errlog = stdout;

--- a/src/help/help/files/cmdcfg/cmd_output_csv.html
+++ b/src/help/help/files/cmdcfg/cmd_output_csv.html
@@ -36,7 +36,9 @@ The syntax of the output_csv command is very similar to that for the list comman
 
 <p class="Commanddefinition">observations</p><p class="Commanddescription">Creates a CSV file of observation data</p>
 
-<p class="Commanddefinition">all</p><p class="Commanddescription">A shorthand for &quot;metadata stations observations&quot;.  (It is recommented that this shorthand is not used in configuration files - just in command files).</p>
+<p class="Commanddefinition">filelist</p><p class="Commanddescription">Creates a CSV file with a catalogue of files used by snap</p>
+
+<p class="Commanddefinition">all</p><p class="Commanddescription">A shorthand for &quot;metadata stations observations filelist&quot;.  (It is recommented that this shorthand is not used in configuration files - just in command files).</p>
 
 <p class="Commanddefinition">tab_delimited</p><p class="Commanddescription">Generate tab delimited files instead of the default comma delimiters</p>
 

--- a/src/site2gps/site2gps.c
+++ b/src/site2gps/site2gps.c
@@ -109,6 +109,8 @@ int main( int argc, char *argv[] )
     int nextstn;
     int block_id;
 
+    CONFIGURE_RUNTIME();
+
     printf("\n%s %s: Creates a dummy GPS data file from a site file and list of lines\n\n",
            PROGRAM_NAME, PROGRAM_VERSION);
 

--- a/src/snap/control.c
+++ b/src/snap/control.c
@@ -59,6 +59,7 @@
 #include "util/dstring.h"
 #include "util/errdef.h"
 #include "util/fileutil.h"
+#include "util/filelist.h"
 #include "util/pi.h"
 #include "util/readcfg.h"
 #include "autofix.h"
@@ -235,6 +236,7 @@ int read_command_file( const char *command_file )
 
     if(cfg)
     {
+        record_filename(get_config_filename(cfg),"command");
         set_config_read_options( cfg, CFG_CHECK_MISSING | CFG_SET_PATH );
         set_config_ignore_flag( cfg, CONSTRAINT_CMD );
         sts = read_config_file( cfg, snap_commands );
@@ -254,7 +256,7 @@ int read_command_file( const char *command_file )
 int read_command_file_constraints( const char *command_file )
 {
     CFG_FILE *cfg;
-
+    int recording=set_record_filenames(0);
     int sts;
 
     cfg = open_config_file( command_file, COMMENT_CHAR );
@@ -270,6 +272,9 @@ int read_command_file_constraints( const char *command_file )
     {
         sts = FILE_OPEN_ERROR;
     }
+
+    set_record_filenames(recording);
+
     return sts;
 }
 
@@ -285,6 +290,7 @@ static int process_configuration_file( const char *file_name, char cfg_only )
     cfg = open_config_file( file_name, COMMENT_CHAR );
     if( cfg )
     {
+        record_filename(get_config_filename(cfg),"configuration");
         set_config_read_options( cfg,  CFG_SET_PATH );
         if( cfg_only ) set_config_command_flag( cfg, CONFIG_CMD );
         else set_config_ignore_flag( cfg, CONSTRAINT_CMD );

--- a/src/snap/control.c
+++ b/src/snap/control.c
@@ -256,7 +256,6 @@ int read_command_file( const char *command_file )
 int read_command_file_constraints( const char *command_file )
 {
     CFG_FILE *cfg;
-    int recording=set_record_filenames(0);
     int sts;
 
     cfg = open_config_file( command_file, COMMENT_CHAR );
@@ -272,8 +271,6 @@ int read_command_file_constraints( const char *command_file )
     {
         sts = FILE_OPEN_ERROR;
     }
-
-    set_record_filenames(recording);
 
     return sts;
 }

--- a/src/snap/cvrfile.c
+++ b/src/snap/cvrfile.c
@@ -29,6 +29,7 @@
 #include "util/chkalloc.h"
 #include "util/progress.h"
 #include "util/dateutil.h"
+#include "util/filelist.h"
 #include "util/dms.h"
 #include "util/xprintf.h"
 #include "util/pi.h"
@@ -66,6 +67,7 @@ void print_coord_covariance( void )
     else
     {
         xprintf("\nCreating the coordinate covariance file %s\n",bfn);
+        record_filename(bfn,"coord_covariance");
     }
     check_free( bfn );
     if( !f ) return;
@@ -171,6 +173,7 @@ void print_coord_covariance_json( void )
     else
     {
         xprintf("\nCreating the JSON coordinate covariance file %s\n",bfn);
+        record_filename(bfn,"coord_covariance_json");
     }
     check_free( bfn );
     if( !f ) return;
@@ -354,6 +357,7 @@ void print_coord_sinex( void )
     else
     {
         xprintf("\nCreating the SINEX file %s\n",bfn);
+        record_filename(bfn,"solution_sinex");
     }
     check_free( bfn );
     if( !f ) return;

--- a/src/snap/grddeform.c
+++ b/src/snap/grddeform.c
@@ -14,7 +14,6 @@
 
 #include "grddeform.h"
 
-/* Watcom doesn't provide M_PI :-( */
 #ifndef M_PI
 #include "util/pi.h"
 #define M_PI PI

--- a/src/snap/output.c
+++ b/src/snap/output.c
@@ -52,6 +52,7 @@
 #include "util/dstring.h"
 #include "util/errdef.h"
 #include "util/fileutil.h"
+#include "util/filelist.h"
 #include "util/leastsqu.h"
 #include "util/license.h"
 #include "util/pi.h"
@@ -162,6 +163,7 @@ static output_option csvopt[] =
     {"correlations",&output_csv_correlations,0,{0},0},
     {"stations",&output_csv_stations,0,{0},0},
     {"observations",&output_csv_obs,0,{0},0},
+    {"filelist",&output_csv_filelist,0,{0},0},
     {"metadata",&output_csv_metadata,0,{0},0},
     {"all",&output_csv_allfiles,0,{0},0},
     {"tab_delimited",&output_csv_tab,0,{0},0},
@@ -392,6 +394,7 @@ int open_output_files( )
         handle_error( FILE_OPEN_ERROR, errmess,"Aborting program");
         return 0;
     }
+    record_filename( lst_name, "listing" );
 
     if( ! output_noruntime ) print_report_header( lst );
 
@@ -406,6 +409,7 @@ int open_output_files( )
         return 0;
     }
 
+    record_filename( lst_name, "error_listing" );
     if( ! output_noruntime ) print_report_header( err );
     print_section_header( err, "ERROR SUMMARY" );
     errcount = 0;
@@ -1040,6 +1044,9 @@ output_csv *open_output_csv(const char *type)
         check_free(filename);
         return 0;
     }
+    char ftype[40];
+    sprintf(ftype,"%.20s_output_csv",type);
+    record_filename(filename,ftype);
 
     csv = (output_csv *) check_malloc( sizeof(output_csv));
     csv->filename = filename;
@@ -1188,6 +1195,7 @@ void print_solution_json_file()
     }
     else
     {
+        record_filename(bfn,"solution_json");
         xprintf("\nCreating the JSON solution file %s\n",bfn);
     }
     check_free( bfn );

--- a/src/snap/output.h
+++ b/src/snap/output.h
@@ -106,6 +106,7 @@ SCOPE char output_csv_vecinline;
 SCOPE char output_csv_vecenu;
 SCOPE char output_csv_correlations;
 SCOPE char output_csv_stations;
+SCOPE char output_csv_filelist;
 SCOPE char output_csv_metadata;
 SCOPE char output_csv_allfiles;
 SCOPE char output_csv_obs;

--- a/src/snap/snapmain.c
+++ b/src/snap/snapmain.c
@@ -1052,7 +1052,7 @@ BINARY_FILE *open_dump_file( void )
     strcpy( bfn, root_name );
     strcat( bfn, BINFILE_EXT );
 
-    record_filename( bfn, "snap_binary_file" );
+    record_filename( bfn, "snap_binary" );
 
     b = create_binary_file( bfn, BINFILE_SIGNATURE );
     if( !b )

--- a/src/snap/stnobseq.c
+++ b/src/snap/stnobseq.c
@@ -33,7 +33,6 @@
 #include "output.h"
 #include "reorder.h"
 #include "residual.h"
-#include "errdef.h"
 #include "snap/deform.h"
 #include "snap/snapglob.h"
 #include "snap/stnadj.h"
@@ -42,6 +41,7 @@
 #include "util/binfile.h"
 #include "util/dateutil.h"
 #include "util/dms.h"
+#include "util/errdef.h"
 #include "util/leastsqu.h"
 #include "util/lsobseq.h"
 #include "util/pi.h"
@@ -1281,14 +1281,14 @@ void print_floated_stations( FILE *out )
         {
             if( rowno==0 ) fprintf( out, "\n");
             double resval=res[rowno];
-            double ser=sqrt(Lij(rescvr,rowno,rowno))*semult;
+            double ser=sqrt(fabs(Lij(rescvr,rowno,rowno)))*semult;
             fprintf( out, "%-*s %-*s  %-5s  %10.4lf  %10.4lf  %10.4lf  %10.4lf ",
                      stn_name_width, (rowno==0 ? st->Code : ""), 
                      relative_floating ? stn_name_width+1 : 0,
                      stcol ? stcol->Code : "",
                      coordname[axis],
                      (axis < 2 ? sa->herror : sa->verror)*semult,
-                     sqrt(Lij(calccvr,rowno,rowno))*semult,
+                     sqrt(fabs(Lij(calccvr,rowno,rowno)))*semult,
                      -resval, ser);
             if( ser > 1.0e-5 )
             {

--- a/src/snap_manager/snap_manager.cpp
+++ b/src/snap_manager/snap_manager.cpp
@@ -326,6 +326,7 @@ IMPLEMENT_APP( SnapMgrApp );
 
 bool SnapMgrApp::OnInit()
 {
+    CONFIGURE_RUNTIME();
     // For help system
     wxFileSystem::AddHandler(new wxZipFSHandler);
     wxString jobfile;

--- a/src/snapadjust/snapadjust_app.cpp
+++ b/src/snapadjust/snapadjust_app.cpp
@@ -12,10 +12,6 @@ public:
     SnapAdjustApp() { }
     virtual bool OnInit()
     {
-        // Need this so that "%n" outputs work!?
-        _set_printf_count_output(1);
-
-
         // create and show the main frame
 
         wxMainProgWindow * mainWin = new wxMainProgWindow("Snap adjustment", true, true );

--- a/src/snapconv/snapconv.c
+++ b/src/snapconv/snapconv.c
@@ -62,6 +62,8 @@ int main( int argc, char *argv[] )
     int degopt = SET_DEGOPT_DEFAULT;
     int hgttype=SET_HGTTYPE_DEFAULT;
 
+    CONFIGURE_RUNTIME();
+
     /* Crude fix to allow suppression of output */
 
     while( argc > 1 && argv[1][0] == '-' )

--- a/src/snapgeoid/snapgeoid.c
+++ b/src/snapgeoid/snapgeoid.c
@@ -65,6 +65,8 @@ int main( int argc, char *argv[] )
     int errlevel=WARNING_ERROR;
     geoid_def *gd = NULL;
 
+    CONFIGURE_RUNTIME();
+
     set_error_file( stdout );
     geoid_msg[0] = 0;
 

--- a/src/snaplib/network/networkl.c
+++ b/src/snaplib/network/networkl.c
@@ -21,6 +21,7 @@
 #include "util/chkalloc.h"
 #include "util/dstring.h"
 #include "util/fileutil.h"
+#include "util/filelist.h"
 #include "util/errdef.h"
 #include "util/polygon.h"
 #include "util/pi.h"
@@ -648,6 +649,7 @@ static int compile_station_list_file_criteria( station_criteria *sc, network *nw
         handle_error( INVALID_DATA, errmess, NULL  );
         return INVALID_DATA;
     }
+    record_filename( spec, "station_list_file" );
 
     skip_utf8_bom(list_file);
 
@@ -824,6 +826,7 @@ static int compile_station_criteria1( station_criteria *sc, network *nw, char *s
                 if( cs ) delete_coordsys( cs );
                 break;
             }
+            record_filename(spec,"wkt_polygon_definition");
             c=new_polygon_criterion( pgn, cs, conv, isgeo, inside );
         }
 

--- a/src/snaplib/network/networkr.c
+++ b/src/snaplib/network/networkr.c
@@ -21,6 +21,7 @@
 #include "util/chkalloc.h"
 #include "util/dstring.h"
 #include "util/datafile.h"
+#include "util/filelist.h"
 #include "util/dms.h"
 #include "util/errdef.h"
 #include "util/pi.h"

--- a/src/snaplib/snap/snapcsvstn.cpp
+++ b/src/snaplib/snap/snapcsvstn.cpp
@@ -10,6 +10,7 @@
 
 #include "util/dateutil.h"
 #include "util/fileutil.h"
+#include "util/filelist.h"
 #include "util/datafile.h"
 #include "util/pi.h"
 
@@ -433,8 +434,13 @@ int load_snap_csv_stations( network *net, const char *filename, const char *opti
         string netname = string("Read from ") + filename;
         set_network_name( net, netname.c_str());
         SnapCsvStn csvstn( net, formatfile, config );
-        DatafileInput dfi( filename,"station file" );
+        DatafileInput dfi( filename,"csv station coordinate file" );
         csvstn.load( dfi );
+        std::string deffile=csvstn.definitionFilename();
+        if( deffile != "" )
+        {
+            record_filename(deffile.c_str(),"csv_station_format");
+        }
         if( dfi.errorCount()) sts = INVALID_DATA;
     }
     catch( RecordError &error )

--- a/src/snaplib/snap/snapcsvstn.cpp
+++ b/src/snaplib/snap/snapcsvstn.cpp
@@ -434,7 +434,7 @@ int load_snap_csv_stations( network *net, const char *filename, const char *opti
         string netname = string("Read from ") + filename;
         set_network_name( net, netname.c_str());
         SnapCsvStn csvstn( net, formatfile, config );
-        DatafileInput dfi( filename,"csv station coordinate file" );
+        DatafileInput dfi( filename,"station coordinate file" );
         csvstn.load( dfi );
         std::string deffile=csvstn.definitionFilename();
         if( deffile != "" )

--- a/src/snaplib/snap/stnadj.c
+++ b/src/snaplib/snap/stnadj.c
@@ -19,6 +19,7 @@
 #include "util/dstring.h"
 #include "util/binfile.h"
 #include "util/fileutil.h"
+#include "util/filelist.h"
 #include "util/get_date.h"
 #include "util/errdef.h"
 #include "util/getversion.h"
@@ -212,8 +213,13 @@ int write_station_file( const char *prog, const char *fname, const char *ver, co
         sprintf(comment,"Updated at %s",rtime);
     }
 
-    return write_network( net, fname, comment, coord_precision,
+    int sts=write_network( net, fname, comment, coord_precision,
                           check_rejected );
+    if( sts == OK )
+    {
+        record_filename( fname, "output_station_coordinate_file" );
+    }
+    return sts;
 }
 
 

--- a/src/snaplib/snap/stnadj.c
+++ b/src/snaplib/snap/stnadj.c
@@ -217,7 +217,7 @@ int write_station_file( const char *prog, const char *fname, const char *ver, co
                           check_rejected );
     if( sts == OK )
     {
-        record_filename( fname, "output_station_coordinate_file" );
+        record_filename( fname, "output_station_coordinate" );
     }
     return sts;
 }

--- a/src/snaplib/snapconfig.h
+++ b/src/snaplib/snapconfig.h
@@ -24,11 +24,11 @@
 #define _strupr(x) {char *c=(x);while(*c){ *c=(char) TOUPPER((int)*c); c++; }}
 #define _strlwr(x) {char *c=(x);while(*c){ *c=(char) TOLOWER((int)*c); c++; }}
 #define _set_output_format(x)
-#define _TWO_DIGIT_EXPONENT
 #define _strdup strdup
 #define _putenv putenv
 #define vsprintf_s vsnprintf
-#define _set_printf_count_output(x) 
+#define CONFIGURE_PRINTF()
+#define CONFIGURE_EXPONENT()
 #define ftell64 ftell
 #define fseek64 fseek
 
@@ -38,14 +38,21 @@
 #else
 // va_copy not defined on Visual Studio pre 2008
 #include <stdarg.h>
+#include <stdio.h>
 #define ftell64 _ftelli64
 #define fseek64 _fseeki64
 #ifndef va_copy
 #define va_copy(dest, src) (dest = src)
 #endif
+/* MS VC compatibility - pre VS 2015 */
+#ifdef _TWO_DIGIT_EXPONENT
+#define CONFIGURE_EXPONENT() _set_output_format(_TWO_DIGIT_EXPONENT)
+#else
+#define CONFIGURE_EXPONENT()
+#endif
+#define CONFIGURE_PRINTF() _set_printf_count_output(1)
 #endif
 
-
-
+#define CONFIGURE_RUNTIME() CONFIGURE_PRINTF(); CONFIGURE_EXPONENT()
 
 #endif

--- a/src/snaplib/snapdata/snapcsvbase.cpp
+++ b/src/snaplib/snapdata/snapcsvbase.cpp
@@ -76,6 +76,7 @@ void SnapCsvBase::loadDefinition()
             loadDefinition( rs );
             terminateLoadDefinition();
             _definitionLoaded = true;
+            _definitionFilename=rs.filename();
         }
         catch(...)
         {
@@ -226,6 +227,7 @@ bool SnapCsvBase::load( RecordInputBase &input )
             loadRecord();
         }
         terminateLoadData();
+        _loadedFilename=input.name();
 
         attachReader(0);
     }

--- a/src/snaplib/snapdata/snapcsvbase.hpp
+++ b/src/snaplib/snapdata/snapcsvbase.hpp
@@ -52,6 +52,8 @@ public:
     void disableColumnCheck( bool check = false ) { _checkColumnEnabled = check; }
     bool load( const std::string &filename );
     bool load( RecordInputBase &input );
+    const std::string &loadedFilename() const { return _loadedFilename; }
+    const std::string &definitionFilename() const { return _definitionFilename; }
 protected:
     // Implementation functions
     virtual void initiallizeLoadDefinition();
@@ -92,6 +94,8 @@ private:
     // CSV format options
     std::string _name;
     std::string _description;
+    std::string _definitionFilename;
+    std::string _loadedFilename;
     std::unique_ptr<Format> _format;
     Options _options;
     std::vector<std::string> _columns;

--- a/src/snaplib/snapdata/snapcsvobs.cpp
+++ b/src/snaplib/snapdata/snapcsvobs.cpp
@@ -16,6 +16,7 @@
 
 #include "util/dateutil.h"
 #include "util/fileutil.h"
+#include "util/filelist.h"
 #include "util/datafile.h"
 #include "util/pi.h"
 #include "util/calcdltfile.hpp"
@@ -1047,6 +1048,11 @@ int load_snap_csv_obs( const char *options, DATAFILE *df, int (*check_progress)(
         SnapCsvObs csvobs( formatfile, config );
         DatafileInput dfi( df, check_progress );
         csvobs.load( dfi );
+        std::string deffile=csvobs.definitionFilename();
+        if( deffile != "" )
+        {
+            record_filename(deffile.c_str(),"csv_obs_format");
+        }
         if( dfi.aborted() ) return OPERATION_ABORTED;
     }
     catch( RecordError &error )

--- a/src/snaplib/util/datafile.c
+++ b/src/snaplib/util/datafile.c
@@ -80,7 +80,9 @@ DATAFILE *df_open_data_file( const char *fname, const char *description )
     strncpy(msg,description,79);
     msg[79]=0;
     for( char *c=msg; *c; c++ ){ if( *c == ' ' ) *c='_'; }
-    record_filename(fname,description);
+    int typelen=strlen(msg);
+    if( typelen > 5 && strcmp(msg+typelen-5,"_file") == 0 ) msg[typelen-5]=0;
+    record_filename(fname,msg);
 
     nch = fread(msg,1,80,f);
     unicode = 0;

--- a/src/snaplib/util/datafile.c
+++ b/src/snaplib/util/datafile.c
@@ -33,6 +33,7 @@
 
 #include "util/chkalloc.h"
 #include "util/fileutil.h"
+#include "util/filelist.h"
 #include "util/datafile.h"
 #include "util/pi.h"
 #include "util/errdef.h"
@@ -75,6 +76,11 @@ DATAFILE *df_open_data_file( const char *fname, const char *description )
         }
         return NULL;
     }
+
+    strncpy(msg,description,79);
+    msg[79]=0;
+    for( char *c=msg; *c; c++ ){ if( *c == ' ' ) *c='_'; }
+    record_filename(fname,description);
 
     nch = fread(msg,1,80,f);
     unicode = 0;

--- a/src/snaplib/util/datafileinput.cpp
+++ b/src/snaplib/util/datafileinput.cpp
@@ -20,6 +20,8 @@ DatafileInput::DatafileInput( const std::string &filename, const std::string &de
         throw RecordError(std::string("Cannot open ") + description + " " + filename );
     }
     _owner = true;
+
+    setName( df_file_name( _df ) );
     df_set_data_file_comment( _df, 0 );
     df_set_data_file_quote( _df, 0 );
     df_set_data_file_continuation( _df, 0 );
@@ -32,6 +34,7 @@ DatafileInput::DatafileInput( DATAFILE *df, int (*check_progress)( DATAFILE *df 
     _aborted(false)
 {
     _owner = false;
+    setName( df_file_name( _df ) );
     df_set_data_file_comment( df, 0 );
     df_set_data_file_quote( df, 0 );
     df_set_data_file_continuation( df, 0 );

--- a/src/snaplib/util/filelist.c
+++ b/src/snaplib/util/filelist.c
@@ -22,7 +22,7 @@ static int maxfilenames=0;
 int set_record_filenames( int record )
 {
     int wasrecording=recording;
-    if( record && filenames )
+    if( record && ! filenames )
     {
         strarray_init(&filetypes);
         filenames= (recfilename *) check_malloc(sizeof(recfilename)*INIT_FILENAME_COUNT);
@@ -37,9 +37,9 @@ int record_filename( const char *filename, const char *filetype )
 {
     if( ! recording ) return NO_FILENAME_ID;
     if( ! filename || ! filetype ) return NO_FILENAME_ID;
-    int typeid=strarray_find(&filetypes,filetype);
-    if( typeid == STRARRAY_NOT_FOUND ) typeid=strarray_add(&filetypes,filetype);
-    filetype=strarray_get(&filetypes,typeid);
+    int ftypeid=strarray_find(&filetypes,filetype);
+    if( ftypeid == STRARRAY_NOT_FOUND ) ftypeid=strarray_add(&filetypes,filetype);
+    filetype=strarray_get(&filetypes,ftypeid);
     filename=copy_string(filename);
     while( nfilenames >= maxfilenames )
     {

--- a/src/snaplib/util/filelist.c
+++ b/src/snaplib/util/filelist.c
@@ -1,5 +1,6 @@
 #include "snapconfig.h"
 #include <stdio.h>
+#include <string.h>
 #include "util/chkalloc.h"
 #include "util/filelist.h"
 #include "util/dstring.h"
@@ -37,6 +38,13 @@ int record_filename( const char *filename, const char *filetype )
 {
     if( ! recording ) return NO_FILENAME_ID;
     if( ! filename || ! filetype ) return NO_FILENAME_ID;
+    for( int i=0; i<nfilenames; i++ )
+    {
+        if( strcmp(filename,filenames[i].filename) == 0 )
+        {
+            return i;
+        }
+    }
     int ftypeid=strarray_find(&filetypes,filetype);
     if( ftypeid == STRARRAY_NOT_FOUND ) ftypeid=strarray_add(&filetypes,filetype);
     filetype=strarray_get(&filetypes,ftypeid);

--- a/src/snaplib/util/filelist.c
+++ b/src/snaplib/util/filelist.c
@@ -1,0 +1,86 @@
+#include "snapconfig.h"
+#include <stdio.h>
+#include "util/chkalloc.h"
+#include "util/filelist.h"
+#include "util/dstring.h"
+#include "util/strarray.h"
+
+#define INIT_FILENAME_COUNT 100
+
+typedef struct 
+{
+    const char *filename;
+    const char *filetype;
+} recfilename;
+
+static int recording=0;
+static strarray filetypes;
+static recfilename *filenames=0;
+static int nfilenames=0;
+static int maxfilenames=0;
+
+int set_record_filenames( int record )
+{
+    int wasrecording=recording;
+    if( record && filenames )
+    {
+        strarray_init(&filetypes);
+        filenames= (recfilename *) check_malloc(sizeof(recfilename)*INIT_FILENAME_COUNT);
+        nfilenames=0;
+        maxfilenames=INIT_FILENAME_COUNT;
+    }
+    recording=record;
+    return wasrecording;
+}
+
+int record_filename( const char *filename, const char *filetype )
+{
+    if( ! recording ) return NO_FILENAME_ID;
+    if( ! filename || ! filetype ) return NO_FILENAME_ID;
+    int typeid=strarray_find(&filetypes,filetype);
+    if( typeid == STRARRAY_NOT_FOUND ) typeid=strarray_add(&filetypes,filetype);
+    filetype=strarray_get(&filetypes,typeid);
+    filename=copy_string(filename);
+    while( nfilenames >= maxfilenames )
+    {
+        maxfilenames *= 2;
+        filenames=(recfilename *) check_realloc(filenames,sizeof(recfilename)*maxfilenames);
+    }
+    filenames[nfilenames].filetype=filetype;
+    filenames[nfilenames].filename=filename;
+    nfilenames++;
+    return nfilenames-1;
+}
+
+int recorded_filename_count()
+{
+    return nfilenames;
+}
+
+const char *recorded_filename( int i, const char **pfiletype )
+{
+    const char *filename=0;
+    const char *filetype=0;
+    if( filenames && i >= 0 && i < nfilenames )
+    {
+        filename=filenames[i].filename;
+        filetype=filenames[i].filetype;
+    }
+    if( pfiletype ) *pfiletype=filetype;
+    return filename;
+}
+
+void delete_recorded_filenames()
+{
+    for( int i = 0; i < nfilenames; i++ )
+    {
+        check_free( (void *) filenames[i].filename);
+    }
+    check_free( filenames );
+    strarray_delete( &filetypes );
+    nfilenames=0;
+    maxfilenames=0;
+    filenames=0;
+}
+
+

--- a/src/snaplib/util/filelist.h
+++ b/src/snaplib/util/filelist.h
@@ -9,6 +9,6 @@ int record_filename( const char *filename, const char *filetype );
 int recorded_filename_count();    
 /* Note: filenames are 0 based */
 const char *recorded_filename( int i, const char **pfiletype );
-void discard_recorded_filenames();
+void delete_recorded_filenames();
 
 #endif

--- a/src/snaplib/util/filelist.h
+++ b/src/snaplib/util/filelist.h
@@ -1,0 +1,14 @@
+#ifndef FILELIST_H
+#define FILELIST_H
+
+#define NO_FILENAME_ID -1
+
+/* Returns previous state of recording filenames */
+int set_record_filenames( int record );
+int record_filename( const char *filename, const char *filetype );
+int recorded_filename_count();    
+/* Note: filenames are 0 based */
+const char *recorded_filename( int i, const char **pfiletype );
+void discard_recorded_filenames();
+
+#endif

--- a/src/snaplib/util/fileutil.c
+++ b/src/snaplib/util/fileutil.c
@@ -102,6 +102,22 @@ int is_dir(const char *path)
         return 0;
 }
 
+time_t  file_modtime(const char *path)
+{
+    struct _stat info;
+    if(_stat( path, &info ) != 0)
+        return 0;
+    return info.st_mtime;
+}
+
+int  file_size(const char *path)
+{
+    struct _stat info;
+    if(_stat( path, &info ) != 0)
+        return 0;
+    return info.st_size;
+}
+
 char *build_config_filespec( char *spec, int nspec,
                              const char *dir, int pathonly, const char *config,
                              const char *name, const char *dflt_ext )

--- a/src/snaplib/util/fileutil.h
+++ b/src/snaplib/util/fileutil.h
@@ -13,6 +13,8 @@
 
 /* fileutil.h: routines to assist file management */
 
+#include <time.h>
+
 #ifndef UNIX
 #define PATH_SEPARATOR '\\'
 #define PATH_SEPARATOR2 '/'
@@ -38,6 +40,9 @@
 
 int path_len( const char *base, int want_name );
 int file_exists( const char *file );
+int is_dir( const char *path );
+int file_size( const char *path );
+time_t file_modtime( const char *path );
 
 /* Compile a filename.  If spec is null then it will return a static variable which
    may be modified by other calls to these routines.
@@ -107,5 +112,7 @@ FILE *snaptmpfile();
 /* Returns 1 if file pointer is not set to the beginning of the file */
 
 int skip_utf8_bom(FILE *f);
+
+time_t file_modtime(const char *filename);
 
 #endif

--- a/src/snaplib/util/recordinputbase.hpp
+++ b/src/snaplib/util/recordinputbase.hpp
@@ -65,6 +65,7 @@ public:
     void raiseError( const std::string message );
     virtual bool handleError( const RecordError &error );
 protected:
+    void setName( const std::string &name ){ _name=name; }
 private:
     std::string _name;
 };

--- a/src/snaplib/util/strarray.c
+++ b/src/snaplib/util/strarray.c
@@ -38,7 +38,7 @@ int strarray_count( strarray *stra )
     return stra->nstrings;
 }
 
-int strarray_find( strarray *stra, char *string )
+int strarray_find( strarray *stra, const char *string )
 {
     int i;
     if( ! stra ) return -1;
@@ -50,7 +50,7 @@ int strarray_find( strarray *stra, char *string )
     return STRARRAY_NOT_FOUND;
 }
 
-static int strarray_add_ptr( strarray *stra, char *string )
+static int strarray_add_ptr( strarray *stra, const char *string )
 {
     if( stra->nstrings >= stra->maxstrings )
     {
@@ -73,12 +73,12 @@ static int strarray_add_ptr( strarray *stra, char *string )
     return stra->nstrings - 1;
 }
 
-int strarray_add( strarray *stra, char *string )
+int strarray_add( strarray *stra, const char *string )
 {
     return strarray_add_ptr( stra, copy_string( string ) );
 }
 
-char *strarray_get( strarray *stra, int i )
+const char *strarray_get( strarray *stra, int i )
 {
     if( stra && i >= 0 && i < stra->nstrings )
     {

--- a/src/snaplib/util/strarray.h
+++ b/src/snaplib/util/strarray.h
@@ -1,9 +1,7 @@
 #ifndef _STRARRAY_H
 #define _STRARRAY_H
 
-/*
-
-*/
+#include <stdio.h>
 
 typedef struct
 {
@@ -17,9 +15,9 @@ void strarray_init( strarray *stra );
 void strarray_delete( strarray *stra );
 
 int strarray_count( strarray *stra );
-int strarray_find( strarray *stra, char *string );
-int strarray_add( strarray *stra, char *string );
-char *strarray_get( strarray *stra, int i );
+int strarray_find( strarray *stra, const char *string );
+int strarray_add( strarray *stra, const char *string );
+const char *strarray_get( strarray *stra, int i );
 
 void dump_strarray( strarray *stra, FILE *f );
 void reload_strarray( strarray *stra, FILE *f );

--- a/src/snaplist/snaplist.c
+++ b/src/snaplist/snaplist.c
@@ -1087,6 +1087,8 @@ int main( int argc, char *argv[] )
     const char *cfn;
     const char *basecfn, *ofn;
 
+    CONFIGURE_RUNTIME();
+
     printf( "snaplist:  Tabulates observations and stations in a SNAP binary file\n");
 
     if( argc != 3 && argc != 4 )

--- a/src/snapmerge/snapmerge.c
+++ b/src/snapmerge/snapmerge.c
@@ -44,6 +44,8 @@ int main( int argc, char *argv[] )
     int clearbaseorders = 0;
     int cleardataorders = 0;
 
+    CONFIGURE_RUNTIME();
+
     while( ! syntaxerror && argc > 1 && argv[1][0] == '-' )
     {
         switch ( argv[1][1] )

--- a/src/snapplot/snapplot_app.cpp
+++ b/src/snapplot/snapplot_app.cpp
@@ -19,12 +19,12 @@ IMPLEMENT_APP(SnapplotApp)
 
 bool SnapplotApp::OnInit()
 {
+
+    CONFIGURE_RUNTIME();
+
     // Needed for zipped help file
     wxFileSystem::AddHandler(new wxZipFSHandler);
     
-    // Need this so that "%n" outputs work!?
-    _set_printf_count_output(1);
-
     // Turn of progress meter as default meter writes to standard output stream
     uninstall_progress_meter();
 


### PR DESCRIPTION
Adds a snap command output_csv filelist which creates a listing of all the files used by snap.  Mainly intended for quality control in the National Geodetic Adjustment.  (Could also be useful for snap_manager in the future)