### PR TITLE
fix: mitigate dense bltreq matrix allocation causing OOM for large networks

### DIFF
--- a/regression_tests/snapspec/check/snapspec2/snapspec2.lst
+++ b/regression_tests/snapspec/check/snapspec2/snapspec2.lst
@@ -1,8 +1,8 @@
-snapspec version 2.8.7-85ee5fb4: Calculation of station orders
-Run at 30-NOV-2023 21:10:23
+snapspec version 2.8.7-9b3457ac: Calculation of station orders
+Run at 15-JUN-2026 13:49:30
 SNAP binary file: snapspec2.bin
 Spec configuration file: snapspec2.cfg
-SNAP run time: 30-NOV-2023 21:10:23
+SNAP run time: 15-JUN-2026 13:49:30
 Running apriori tests
 
 
@@ -67,7 +67,7 @@ Applying relative accuracy test
    .. Orders updated took 0.00 seconds (total 0.00 seconds)
    .. Calculating missing covariances took 0.00 seconds (total 0.00 seconds)
    Calculating covariances from decomposition
-   Matrix size 10 rows 55 elements 100.00% full
+   Matrix size 10 rows 16 elements 29.09% full
    .. Calculation of missing covariances complete took 0.00 seconds (total 0.00 seconds)
 
 Pass 2: Calculating with extra covariance information

--- a/regression_tests/snapspec/check/snapspec5/snapspec5.lst
+++ b/regression_tests/snapspec/check/snapspec5/snapspec5.lst
@@ -1,9 +1,9 @@
-snapspec version 2.8.7-85ee5fb4: Calculation of station orders
-Run at 30-NOV-2023 21:10:23
+snapspec version 2.8.7-9b3457ac: Calculation of station orders
+Run at 15-JUN-2026 13:49:30
 SNAP binary file: snapspec5.bin
 Spec configuration file: snapspec5.cfg
 Vertical tests will not be applied as no stations are adjusted vertically
-SNAP run time: 30-NOV-2023 21:10:23
+SNAP run time: 15-JUN-2026 13:49:30
 Running apriori tests
 
 
@@ -68,7 +68,7 @@ Applying relative accuracy test
    .. Orders updated took 0.00 seconds (total 0.00 seconds)
    .. Calculating missing covariances took 0.00 seconds (total 0.00 seconds)
    Calculating covariances from decomposition
-   Matrix size 10 rows 55 elements 100.00% full
+   Matrix size 10 rows 16 elements 29.09% full
    .. Calculation of missing covariances complete took 0.00 seconds (total 0.00 seconds)
 
 Pass 2: Calculating with extra covariance information

--- a/src/snapspec/snapspec.c
+++ b/src/snapspec/snapspec.c
@@ -320,7 +320,8 @@ static int relacc_create_blt_req( stn_relacc_array *ra )
 {
     if( ! ra->bltreq )
     {
-        ra->bltreq = create_bltmatrix( ra->bltdec->nrow ); 
+        ra->bltreq = create_bltmatrix( ra->bltdec->nrow );
+        blt_set_sparse_rows( ra->bltreq, ra->bltdec->nrow );
         if( ra->blt )
         {
             copy_bltmatrix_bandwidth( ra->blt, ra->bltreq );


### PR DESCRIPTION
`create_bltmatrix()` sets `nsparse=0`. `blt_requested_size()` reads `nsparse=0` and sets all `r->req=0` as a side effect, destroying the values accumulated by the pair-loop. `copy_bltmatrix()` then calls `copy_bltmatrix_bandwidth()` which sets `nsparse=nrow`, followed by `alloc_bltrow_arrays()` which allocates `i+1-r->req` elements per row — full width since `r->req=0`. For the NZ network (122,317 stations, 137,801-row matrix) this produces a ~52 GB allocation.

Fix: call `blt_set_sparse_rows(bltreq, nrow)` immediately after creation. This one-line fix sets `nsparse=nrow` so `blt_requested_size()` does not fire the destructive branch and the pair-loop's req values are preserved.

The resulting row widths are still correct. The pair-loop calls `blt_nonzero_element()` for each station pair that needs a covariance element, which only ever decreases `req` (widens a row), so requests accumulate correctly into `bltreq` regardless of `nsparse`. `copy_bltmatrix()` in `relacc_calc_requested_covar()` then seeds `bltreq` with `bltdec`'s bandwidth via `copy_bltmatrix_bandwidth()` before allocating, so the final `blt` is allocated at exactly `UNION(pair-loop requests, bltdec bandwidth)` — neither full-width nor diagonal-only.

A follow-up refactor (refactor/snapspec-single-cholesky-creation) will avoid holding the Cholesky factor (`bltdec`) in memory alongside the inverted covariance matrix (`blt`), reducing peak memory further.