### PR TITLE
fix: run apt-get update synchronously before install in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3.6.0
       - name: Install dependencies
         run: |
-          sudo apt-get update &
+          sudo apt-get update
           DEBIAN_FRONTEND=noninteractive sudo apt-get install g++ libboost-dev libboost-math-dev libboost-regex-dev libboost-filesystem-dev python3
         # Remove warnings for missing wx-config.  Need to fix build to only use wx-config for building programs that need it.
       - name: Setup wx-config dummy command


### PR DESCRIPTION
The & ran apt-get update in the background, creating a race condition where apt-get install could start before the package lists were refreshed. This caused spurious failures on ubuntu-24.04 when apt resolved stale version numbers that were no longer available in the mirrors.