### PR TITLE
chore: remove Register for notifications menu item

### DIFF
--- a/src/snap_manager/config/snapscript/snap_manager.cfg
+++ b/src/snap_manager/config/snapscript/snap_manager.cfg
@@ -9,8 +9,7 @@ $_startup_message =
                             Welcome to SNAP.
 
   Please note that this software is provided with no warranty - see Help|About
-  for more information. See Help|Register to register for email notifications 
-  of updates to SNAP.
+  for more information.
 
   Snap comprises a suite of programs for adjusting and analysing survey data.
   Most of these tools are accessed from the menus above.  
@@ -67,10 +66,6 @@ $_geoids=$_geoids."~egm96~EGM96"
 # Save the initial SNAPDIR environment variable (for LogConfig function)
 
 $_snapdirenv=GetEnv("SNAPDIR")
-
-# Url for registering for SNAP notifications
-
-$_registerurl="http://eepurl.com/dcJTJT"
 
 #############################################################################
 # NOTE: All menu actions implemented by functions to allow them to be
@@ -292,14 +287,6 @@ menu_item "&Tools|&List installed packages" "List the packages currently install
 actions
    ListInstalledPackages()
 end_menu_item   
-
-#==================================================
-
-menu_item "&Help|&Register for notifications" "Register to receive email notifications of updates"
-actions
-   BrowseFile($_registerurl)
-end_menu_item
-
 
 #########################################################################
 # Menu functions


### PR DESCRIPTION
Drops the Help menu link and Mailchimp signup URL used to open an email-notifications registration page in the default browser.

Tested in Windows sandbox VM.