### PR TITLE
fix: add favicon to SNAP help pages

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -178,6 +178,10 @@ install(CODE "
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/help/help/
     DESTINATION ${SNAP_INSTALL_ROOT}/help)
 
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/resources/snap.ico
+    DESTINATION ${SNAP_INSTALL_ROOT}/help
+    RENAME favicon.ico)
+
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/src/packages/devel/
         DESTINATION ${SNAP_INSTALL_ROOT}/config/package/devel)

--- a/src/help/build_help.py
+++ b/src/help/build_help.py
@@ -18,6 +18,7 @@ TEMPLATE="""
 <html>
 <head>
 <title><!--TITLE--></title>
+<link rel="icon" href="favicon.ico">
 <link rel="stylesheet" href="css/helpapp.css">
 <style media="print">#menu { display: none }</style>
 <script src="js/jquery.min.js" ></script>

--- a/src/help/help/index.html
+++ b/src/help/help/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 <title>SNAP help</title>
+<link rel="icon" href="favicon.ico">
 <link rel="stylesheet" href="css/helpapp.css">
 <style media="print">#menu { display: none }</style>
 <script src="js/jquery.min.js" ></script>


### PR DESCRIPTION
The Help menu opens the help system in the default browser, but the tab showed no icon since no page linked a favicon. Install snap.ico as favicon.ico alongside the help files at build time rather than duplicating the binary in source control.

Tested in Windows sandbox VM.