### PR TITLE
fix: bin-file locations silently truncated past 2GB on Windows

### DIFF
--- a/src/dat2site/dat2site.cpp
+++ b/src/dat2site/dat2site.cpp
@@ -759,11 +759,11 @@ static void load_data( survdata *sd )
 
 // #pragma warning (disable : 4100)
 
-static long get_id( int type, int, const char *code )
+static int64_t get_id( int type, int, const char *code )
 {
     if( type == ID_STATION )
     {
-        return (long) get_station_id( code );
+        return (int64_t) get_station_id( code );
     }
     else if ( type == ID_PROJCTN )
     {

--- a/src/snap/bindata2.cpp
+++ b/src/snap/bindata2.cpp
@@ -1207,7 +1207,6 @@ void print_residuals( FILE *out )
 {
     bindata *b;
     double semult;
-    long loc;
     long nbin;
     survdata *sd;
 
@@ -1386,7 +1385,7 @@ void print_residuals( FILE *out )
     {
         if( sort_obs )
         {
-            loc = get_sorted_obs_loc();
+            const int64_t loc = get_sorted_obs_loc();
             if( loc < 0 ) break;
             init_get_bindata( loc );
         }

--- a/src/snap/loadsnap.cpp
+++ b/src/snap/loadsnap.cpp
@@ -328,7 +328,6 @@ static int split_obsdata_for_schreiber( survdata *sd )
 static void save_split_survdata( survdata *sd )
 {
     unsigned char typesaved[NOBSTYPE];
-    long loc;
     int iobs, sobs, to;
     trgtdata *t;
 
@@ -347,7 +346,7 @@ static void save_split_survdata( survdata *sd )
         {
             sobs = iobs;
         }
-        loc = save_survdata_subset( sd, sobs, t->type );
+        const int64_t loc = save_survdata_subset( sd, sobs, t->type );
         to = t->to;
         if( sobs < 0 ) to = 0;
         if( t->type == GB && sd->nobs == 1 ) to = t->to;
@@ -357,10 +356,9 @@ static void save_split_survdata( survdata *sd )
 
 static void save_whole_survdata( survdata *sd )
 {
-    long loc;
     int to;
     trgtdata *t;
-    loc = save_survdata( sd );
+    const int64_t loc = save_survdata( sd );
     to = 0;
     t = get_trgtdata( sd, 0 );
     if( sd->nobs == 1 ) to = t->to;
@@ -433,9 +431,9 @@ static void load_snap( survdata *sd )
 /* Callback function used by loaddata to get id's of various objects */
 
 
-static long snap_id( int type, int group_id, const char *code )
+static int64_t snap_id( int type, int group_id, const char *code )
 {
-    long id;
+    int64_t id;
     id = 0;
     switch (type)
     {

--- a/src/snap/notedata.cpp
+++ b/src/snap/notedata.cpp
@@ -25,27 +25,15 @@
 /* If the note is continued, the first character is set to blank,
    otherwise it is a line-feed character */
 
-long save_note( const char *text, int continued )
+int64_t save_note( const char *text, int continued )
 {
     int nch;
-    int64_t noteloc;
-    long size, loc;
+    int64_t loc;
+    long size;
     nch = strlen( text );
     size = nch+3;
 
-    // For the moment we don't want to propogate int64_t to 
-    // the note id (which is a file location), as this would then
-    // impact on snap_id, and thence to all ids.  This can be 
-    // sorted as/when the snap code base gets a proper overhaul.
-    //
-    // In practice long will be big enough as binary files are 
-    // unlikely to exceed 2Gb until the covariance data is written to
-    // them, and this is after the notes have been written (which
-    // is during the data load phase).
-
-    noteloc = write_bindata_header( size, NOTEDATA );
-    loc = (long) noteloc;
-    if (loc != noteloc) loc = 0;
+    loc = write_bindata_header( size, NOTEDATA );
 
     fputc( continued ? ' ' : '\n', bindata_file );
     fwrite( text, nch, 1, bindata_file );
@@ -57,7 +45,7 @@ long save_note( const char *text, int continued )
 
 
 
-void list_note( FILE *out, long loc )
+void list_note( FILE *out, int64_t loc )
 {
     int64_t curloc;
     char note[81];
@@ -66,7 +54,7 @@ void list_note( FILE *out, long loc )
     int firstline, c;
     if( loc < 0 || !output_notes ) return;
     curloc = ftell64( bindata_file );
-    fseek( bindata_file, loc, SEEK_SET );
+    fseek64( bindata_file, loc, SEEK_SET );
 
     firstline = 1;
     while( read_bindata_header( &size, &type ) && type == NOTEDATA )

--- a/src/snap/notedata.h
+++ b/src/snap/notedata.h
@@ -8,7 +8,9 @@
 
 */
 
-long save_note( const char *note, int continued );
-void list_note( FILE *out, long loc );
+#include <stdint.h>
+
+int64_t save_note( const char *note, int continued );
+void list_note( FILE *out, int64_t loc );
 
 #endif

--- a/src/snap/residual.cpp
+++ b/src/snap/residual.cpp
@@ -55,7 +55,7 @@ typedef struct
     int line;
     char unused;
     double sres;
-    long note;
+    int64_t note;
 } residual;
 
 #define MAXRANK 3
@@ -140,7 +140,7 @@ const char *residual_flag( int unused, int rank, double sres )
 
 
 void save_residual( int from, int to, int id, int type,
-                    int file, int line, char unused, int rank, double sres, long note )
+                    int file, int line, char unused, int rank, double sres, int64_t note )
 {
     int i, level;
     int used;

--- a/src/snap/residual.h
+++ b/src/snap/residual.h
@@ -8,9 +8,11 @@
 
 */
 
+#include <stdint.h>
+
 const char *residual_flag( int unused, int rank, double sres );
 void save_residual( int from, int to, int id, int type,
-                    int file, int line, char unused, int rank, double sres, long loc );
+                    int file, int line, char unused, int rank, double sres, int64_t loc );
 void print_worst_residuals( FILE *out );
 
 #endif

--- a/src/snap/sortobs.cpp
+++ b/src/snap/sortobs.cpp
@@ -26,13 +26,13 @@ typedef struct
     int from;  /* From station */
     int to;    /* To station, or 0 if there are several */
     int type;  /* Observation type */
-    long loc;  /* File location */
+    int64_t loc;  /* File location */
 } obsdef;
 
 typedef union
 {
     obsdef *ptr;
-    long loc;
+    int64_t loc;
 } obsloc;
 
 static void *obsdeflst = NULL;
@@ -40,7 +40,7 @@ static obsloc *obslst = NULL;
 static int nobslst = 0;
 static int nextobs = 0;
 
-void save_observation( int from, int to, int type, long loc )
+void save_observation( int from, int to, int type, int64_t loc )
 {
     obsdef *o;
     if( !obsdeflst ) obsdeflst = create_list( sizeof(obsdef) );
@@ -93,7 +93,7 @@ void sort_observation_list( void )
 
     /* Create an index array */
 
-    obslst = (obsloc *) check_malloc( sizeof(obslst) * nobslst );
+    obslst = (obsloc *) check_malloc( sizeof(*obslst) * nobslst );
 
     /* Copy the locations of the definitions into the list */
 
@@ -127,7 +127,7 @@ void init_get_sorted_obs_loc( void )
 }
 
 
-long get_sorted_obs_loc( void )
+int64_t get_sorted_obs_loc( void )
 {
     if( nextobs >= nobslst ) return -1;
     if( !obslst ) sort_observation_list();

--- a/src/snap/sortobs.h
+++ b/src/snap/sortobs.h
@@ -10,10 +10,12 @@
 #ifndef _SORTOBS_H
 #define _SORTOBS_H
 
-void save_observation( int from, int to, int type, long loc );
+#include <stdint.h>
+
+void save_observation( int from, int to, int type, int64_t loc );
 void sort_observation_list( void );
 void init_get_sorted_obs_loc( void );
-long get_sorted_obs_loc( void );
+int64_t get_sorted_obs_loc( void );
 
 #ifdef SORTOBS_C
 int sort_obs = 0;

--- a/src/snaplib/snap/bindata.cpp
+++ b/src/snaplib/snap/bindata.cpp
@@ -63,7 +63,7 @@ void init_get_bindata(int64_t loc )
 int64_t write_bindata_header( long size, int type )
 {
     int64_t loc;
-    loc = ftell( bindata_file );
+    loc = ftell64( bindata_file );
     fwrite( &size, sizeof(size), 1, bindata_file );
     fwrite( &type, sizeof(type), 1, bindata_file );
     if( size > maxsize ) maxsize = size;
@@ -89,7 +89,7 @@ static void reset_survdata_pointers( survdata *sd );
 
 int get_bindata( int bintype, bindata *b )
 {
-    long loc;
+    int64_t loc;
     int sts;
 
 
@@ -224,23 +224,9 @@ static long survdata_size( survdata *sd )
 	       not saved.
      */
 
-long save_survdata( survdata *sd )
+int64_t save_survdata( survdata *sd )
 {
-    int64_t fileloc;
-    long loc;
-    // Cannot handle locations which are not within the range of long 
-    // at the moment (and on MSW 64 long is 4 bytes).  This should be ok as 
-    // observations are loaded into the binary file before the covariance 
-    // which is the only bit likely to push the size over 2Gb.  For the moment
-    // accept this limitation - this can be fixed as/when the snap codebase
-    // is overhauled.
-    fileloc = write_bindata_header(survdata_size(sd), SURVDATA);
-    loc = (long)fileloc;
-    if (loc != fileloc)
-    {
-        loc = 0;
-        handle_error( FATAL_ERROR, "Cannot save data in binary file - too much data","");
-    }
+    const int64_t loc = write_bindata_header(survdata_size(sd), SURVDATA);
     fwrite( sd, sizeof(survdata), 1, bindata_file );
     fwrite( sd->obs.odata, sd->obssize, sd->nobs, bindata_file );
     if( sd->nclass )
@@ -274,11 +260,10 @@ long save_survdata( survdata *sd )
     return loc;
 }
 
-long save_survdata_subset( survdata *sd, int iobs, int type )
+int64_t save_survdata_subset( survdata *sd, int iobs, int type )
 {
     int nobs, nclass, nsyserr;
     int cvrperobs, cvrtype;
-    int64_t loc;
     int i, i0, i1;
 
     /* Determine the possible range of observations */
@@ -323,35 +308,24 @@ long save_survdata_subset( survdata *sd, int iobs, int type )
     cvrperobs = sd->ncvr/sd->nobs;
     if( !sd->cvr ) cvrperobs = 0;
 
-    {
-        int oldnobs, oldnclass, oldnsyserr, oldncvr;
-        int64_t fileloc;
+    const int oldnobs = sd->nobs;
+    const int oldnclass = sd->nclass;
+    const int oldnsyserr = sd->nsyserr;
+    const int oldncvr = sd->ncvr;
 
-        oldnobs = sd->nobs;
-        oldnclass = sd->nclass;
-        oldnsyserr = sd->nsyserr;
-        oldncvr = sd->ncvr;
+    sd->nobs = nobs;
+    sd->nclass = nclass;
+    sd->nsyserr = nsyserr;
+    sd->ncvr = cvrperobs * nobs;
 
-        sd->nobs = nobs;
-        sd->nclass = nclass;
-        sd->nsyserr = nsyserr;
-        sd->ncvr = cvrperobs * nobs;
+    const int64_t loc = write_bindata_header( survdata_size( sd ), SURVDATA );
 
-        fileloc = write_bindata_header( survdata_size( sd ), SURVDATA );
-        loc = (long)fileloc;
-        if (loc != fileloc)
-        {
-            loc = 0;
-            handle_error(FATAL_ERROR, "Cannot save data in binary file - too much data", "");
-        }
+    fwrite( sd, sizeof(survdata), 1, bindata_file );
 
-        fwrite( sd, sizeof(survdata), 1, bindata_file );
-
-        sd->nobs = oldnobs;
-        sd->nclass = oldnclass;
-        sd->nsyserr = oldnsyserr;
-        sd->ncvr = oldncvr;
-    }
+    sd->nobs = oldnobs;
+    sd->nclass = oldnclass;
+    sd->nsyserr = oldnsyserr;
+    sd->ncvr = oldncvr;
 
     /* Save the observations */
 

--- a/src/snaplib/snap/bindata.h
+++ b/src/snaplib/snap/bindata.h
@@ -46,8 +46,8 @@ void update_bindata( bindata *b );
 bindata *create_bindata( void );
 void delete_bindata( bindata *b );
 
-long save_survdata( survdata *sd );
-long save_survdata_subset( survdata *sd, int iobs, int type );
+int64_t save_survdata( survdata *sd );
+int64_t save_survdata_subset( survdata *sd, int iobs, int type );
 
 char *get_obs_classification_name( survdata *sd, trgtdata *t, int class_id );
 

--- a/src/snaplib/snapdata/loaddata.cpp
+++ b/src/snaplib/snapdata/loaddata.cpp
@@ -47,7 +47,7 @@ static trgtdata *tgt = NULL;
 static int tgt_id=0;
 static double tgt_hgt;
 static long file_lineno;
-static long noteloc;
+static int64_t noteloc;
 static int inst_cancelled;
 static int trgt_cancelled;
 static int data_cancelled;
@@ -130,7 +130,7 @@ void (*usedata_func)( survdata *sd );
 /* The functions for converting codes to and from numeric id's,
    and for calculating values  */
 
-static long (*id_func)( int type, int group_id, const char *code );
+static int64_t (*id_func)( int type, int group_id, const char *code );
 static const char * (*code_func)( int type, int group_id, long id );
 static double (*calc_func)( int type, long id1, long id2 );
 
@@ -342,7 +342,7 @@ static void report_error( const char *location )
 }
 
 void init_load_data( void (*usedata)( survdata *sd ),
-                     long (*idfunc)( int type, int group_id, const char *code ),
+                     int64_t (*idfunc)( int type, int group_id, const char *code ),
                      const char * (*codefunc)( int type, int group_id, long id ),
                      double (*calcfunc)( int type, long id1, long id2 ))
 {
@@ -719,7 +719,7 @@ static classdata *getclassdata( void )
     return classblock + idx;
 }
 
-long ldt_get_id( int type, int group_id, const char *code )
+int64_t ldt_get_id( int type, int group_id, const char *code )
 {
     if( type == ID_STATION && recoding )
     {
@@ -1042,15 +1042,13 @@ void ldt_vecsyserr( int syserr_id, double influence[] )
 
 void ldt_prefix_note( const char *note )
 {
-    long newnote;
     DEBUG_PRINT(("LDT: ldt_prefix_note %s",note));
-    newnote = ldt_get_id( ID_NOTE, noteloc ? 1 : 0, note );
+    const int64_t newnote = ldt_get_id( ID_NOTE, noteloc ? 1 : 0, note );
     if( !noteloc ) noteloc = newnote;
 }
 
 void ldt_note( const char *note )
 {
-    long newnote;
     DEBUG_PRINT(("LDT: ldt_note %s",note));
 
     if( !tgt )
@@ -1058,7 +1056,7 @@ void ldt_note( const char *note )
         report_error( "ldt_postfix_note" );
         return;
     }
-    newnote = ldt_get_id( ID_NOTE, tgt->noteloc ? 1 : 0, note );
+    const int64_t newnote = ldt_get_id( ID_NOTE, tgt->noteloc ? 1 : 0, note );
     if( !tgt->noteloc ) tgt->noteloc = newnote;
 }
 

--- a/src/snaplib/snapdata/loaddata.h
+++ b/src/snaplib/snapdata/loaddata.h
@@ -8,6 +8,8 @@
 
 */
 
+#include <stdint.h>
+
 #ifndef _DATATYPE_H
 #include "snapdata/datatype.h"
 #endif
@@ -79,7 +81,7 @@ void set_coef_class( int coeftype, const char *name );
    before and after loading a data file */
 
 void init_load_data( void (*usedata_func)( survdata *sd ),
-                     long (*idfunc)( int type, int group_id, const char *code ),
+                     int64_t (*idfunc)( int type, int group_id, const char *code ),
                      const char * (*namefunc)( int type, int group_id, long id ),
                      double (*calcfunc)( int type, long id1, long id2 ));
 void term_load_data( void );
@@ -107,7 +109,7 @@ void set_gpscvr_func( void (*func)( survdata *vd, int cvrtype,
    data routines assemble these to convert the data to a standard internal
    format */
 
-long ldt_get_id( int type, int group_id, const char *code );
+int64_t ldt_get_id( int type, int group_id, const char *code );
 const char *ldt_get_code( int type, int group_id, long id );
 double ldt_calc_value( int calc_type, long id1, long id2 );
 

--- a/src/snaplib/snapdata/survdata.h
+++ b/src/snaplib/snapdata/survdata.h
@@ -8,6 +8,8 @@
 
 */
 
+#include <stdint.h>
+
 #ifndef _SYMMATRX_H
 #include "util/symmatrx.h"
 #endif
@@ -58,7 +60,7 @@ typedef struct
     int  nsyserr;   /* Number of systematic errors */
     int  isyserr;   /* Index of first systematic error in array of syserrs */
     char   unused;  /* Flags whether the observation has been rejected */
-    long   noteloc; /* Identifies a note associated with the obs */
+    int64_t noteloc; /* Identifies a note associated with the obs */
     double errfct;  /* Error factor applied to the obs by obs modifications */
 } trgtdata;
 

--- a/src/snapplot/loadplot.cpp
+++ b/src/snapplot/loadplot.cpp
@@ -106,9 +106,9 @@ static void list_missing_stations( void )
 }
 
 
-static long snap_id( int type, int group_id, const char *code )
+static int64_t snap_id( int type, int group_id, const char *code )
 {
-    long id;
+    int64_t id;
     id = 0;
     switch (type)
     {

--- a/src/snapplot/plotbin.cpp
+++ b/src/snapplot/plotbin.cpp
@@ -109,7 +109,7 @@ void load_observations_from_binary( void )
 #define NOTEWIDTH 90
 #define NOTEPREFIX 6
 
-void display_note_text( void *dest, PutTextFunc f, long loc )
+void display_note_text( void *dest, PutTextFunc f, int64_t loc )
 {
     PutTextInfo jmp;
     int64_t curloc;
@@ -162,7 +162,7 @@ static int reload_observations( BINARY_FILE *bf )
     return OK;
 }
 
-survdata *get_survdata_from_binary( long loc )
+survdata *get_survdata_from_binary( int64_t loc )
 {
     if( !bd ) bd = create_bindata();
     init_get_bindata( loc );

--- a/src/snapplot/plotbin.h
+++ b/src/snapplot/plotbin.h
@@ -27,8 +27,8 @@ void load_observations_from_binary( void );
 void open_data_source( void );
 void close_data_source( void );
 
-survdata *get_survdata_from_binary( long loc );
-void display_note_text( void *dest, PutTextFunc f, long loc );
+survdata *get_survdata_from_binary( int64_t loc );
+void display_note_text( void *dest, PutTextFunc f, int64_t loc );
 
 #endif
 

--- a/src/snapplot/plotconn.cpp
+++ b/src/snapplot/plotconn.cpp
@@ -103,7 +103,7 @@ typedef struct
     float sres;            /* standardised residual */
     float rfac;            /*  factor */
     double date;           /*  date of observation */
-    long bloc;             /* location of binary data in data source */
+    int64_t bloc;          /* location of binary data in data source */
     int idata;           /* Index of data in data block in file */
     int cclass[1];        /* Classifications */
 } conn_data;
@@ -587,7 +587,7 @@ static int get_connection_to_id( int from, int to )
 }
 
 
-static int get_connection_obs_id( int from, int to_id, long bloc, int index )
+static int get_connection_obs_id( int from, int to_id, int64_t bloc, int index )
 {
     fconn_ptr *fp;
     tconn_ptr *tp;
@@ -632,7 +632,7 @@ int have_binary_data()
     return binary_data;
 }
 
-void add_survdata_connections( survdata *sd, long bloc )
+void add_survdata_connections( survdata *sd, int64_t bloc )
 {
     trgtdata *t;
     int i, j, iclass;
@@ -2759,7 +2759,7 @@ static double degree_angle( double rad )
     return angle;
 }
 
-void list_obsdata( void *dest, PutTextFunc f, survdata *sd, long binloc, int index )
+void list_obsdata( void *dest, PutTextFunc f, survdata *sd, int64_t binloc, int index )
 {
     PutTextInfo jmp;
     obsdata *o;
@@ -2995,7 +2995,7 @@ void list_obsdata( void *dest, PutTextFunc f, survdata *sd, long binloc, int ind
 }
 
 void list_vecdata( void *dest, PutTextFunc f, survdata *sd, unsigned char flags,
-                   long bloc, int index )
+                   int64_t bloc, int index )
 {
     PutTextInfo jmp;
     vecdata *v;

--- a/src/snapplot/plotconn.h
+++ b/src/snapplot/plotconn.h
@@ -11,6 +11,8 @@
 
 */
 
+#include <stdint.h>
+
 #ifndef _DATATYPE_H
 #include "snapdata/datatype.h"
 #endif
@@ -29,7 +31,7 @@
 
 void set_binary_data( int status );
 int have_binary_data( void );
-void add_survdata_connections( survdata *sd, long bloc );
+void add_survdata_connections( survdata *sd, int64_t bloc );
 void add_relative_covariance( int from, int to, double cvr[6] );
 
 #define DPEN_BY_TYPE -1


### PR DESCRIPTION
This is a FAT16-era failure mode — a ~2GB ceiling rooted in 32-bit `long` on
MSVC (LLP64), the same class of limit that capped FAT16 file sizes in the
1990s. It surfaced while preparing the `.bin` file format to be genuinely
portable between Windows and Unix builds (see the companion cross-platform
`.bin` format work): retyping `trgtdata.noteloc` for byte-layout reasons
prompted checking whether its value could actually survive intact end to
end, and turned up this potential issue. It is independent of that
portability work and predates it.

`write_bindata_header()` declared its return as `int64_t` but computed it
via plain `ftell()`, whose return type is only a 32-bit `long` on MSVC
(LLP64) — so on Windows, every location it returned would likely already be
wrong past ~2GB, regardless of the wider return type. This is based on
static analysis (the codebase's own `ftell64`/`fseek64` split in
`snapconfig.h` exists for exactly this reason) rather than testing on an
actual Windows build.

`save_survdata()`/`save_survdata_subset()` and `save_note()` each compound
the root bug in their own way:

- `save_survdata()`/`save_survdata_subset()` had their own, independent
  narrowing: their declared return type was `long`, and `save_survdata()`
  cast the result down to a local `long` before returning it. Even with a
  fully correct `write_bindata_header()`, these functions would still have
  discarded a valid 64-bit position through their return type.
- `save_note()` made a deliberate design choice: it explicitly casts down
  to `long` and zeroes the note reference on mismatch, per its own comment
  about "not want[ing] to propagate `int64_t` to the note id... In practice
  `long` will be big enough."

Both paths also called `handle_error(FATAL_ERROR, ...)` or silently zeroed
the value on a detected mismatch — `save_survdata()`'s `FATAL_ERROR` calls
`exit()`, so on Windows, saving a survey-data record past the 2GB mark in a
`.bin` file would likely abort the whole `snap` run, not just misbehave.
This looks like a plausible failure mode for large jobs on Windows builds.

Fixed at the root (`ftell` → `ftell64`) and widened every place a bin-file
location is stored or passed along, so a real 64-bit position survives end
to end instead of being re-truncated further down the chain:

- `notedata.cpp`/`.h`
- `residual.cpp`/`.h`
- `sortobs.cpp`/`.h`
- `loadsnap.cpp`
- `loadplot.cpp`
- `dat2site.cpp`
- `loaddata.cpp`/`.h`
- `plotbin.cpp`/`.h`
- `plotconn.cpp`/`.h`
- `survdata.h` (`trgtdata.noteloc`)
- `bindata.cpp`/`.h` (`save_survdata`/`save_survdata_subset` now return
  `int64_t`, with the truncate-and-guard removed since it's no longer
  needed)

Also fixes a related bug in `sortobs.cpp`'s `sort_observation_list()`:
`check_malloc(sizeof(obslst) * nobslst)` used the pointer's own size instead
of `sizeof(*obslst)` — currently harmless since a pointer and the `obsloc`
union it points to are both 8 bytes on x86_64, but fragile if the union
ever grows a larger member.

## Test plan

- [x] Full clean rebuild
- [x] Complete regression suite (694 tests across `concord`/`dat2site`/
      `snap`/`snapconv`/`snapgeoid`/`snapmerge`/`snapspec`/`snapspec_k`,
      0 failures)
- [ ] Not yet verified on an actual Windows build (testing so far is
      Unix-only; the fix is based on static analysis of the MSVC/LLP64
      `long` vs `ftell64` mismatch)