### PR TITLE
fix: snapplot zoom rectangle broken on modern GTK3/Wayland, modernize…

### DIFF
--- a/src/snapplot/snapplot_mapview.cpp
+++ b/src/snapplot/snapplot_mapview.cpp
@@ -348,6 +348,11 @@ void SnapplotMapView::ClearLocator()
 void SnapplotMapView::PaintLocator( wxDC &dc )
 {
     RestoreMapImage(dc);
+    DrawLocator(dc);
+}
+
+void SnapplotMapView::DrawLocator( wxDC &dc )
+{
     if( locatorFrom == 0 ) return;
     wxColour locatorCol = GetSymbology()->LayerColour( get_pen( SELECTED_PEN ) );
     wxColour backCol = GetSymbology()->LayerColour( get_pen( BACKGROUND_PEN ) );
@@ -464,7 +469,7 @@ void SnapplotMapView::OnPaint( wxPaintEvent & WXUNUSED(event) )
     wxPaintDC dc(this);
     PaintMap(dc);
     SaveMapImage();
-    PaintLocator(dc);
+    DrawLocator(dc);
 }
 
 // Routine generates a bitmap image that is a copy of contents of the screen map,

--- a/src/snapplot/snapplot_mapview.hpp
+++ b/src/snapplot/snapplot_mapview.hpp
@@ -39,6 +39,7 @@ private:
     void SetLocatorLocked( bool locked );
     void PaintLocator();
     void PaintLocator( wxDC &dc );
+    void DrawLocator( wxDC &dc );
     void ClearLocator();
 
     void SaveMapImage();

--- a/src/wxtest/wxmapwindow.cpp
+++ b/src/wxtest/wxmapwindow.cpp
@@ -2,6 +2,11 @@
 
 #include "wxmapwindow.hpp"
 
+static_assert( false, "wxtest/wxmapwindow.cpp duplicates wxutils/wxmapwindow.cpp's "
+    "wxMapDragger, including its older wxINVERT/XOR rubber-band drawing, which fails on "
+    "modern GTK3/Wayland - apply the same wxOverlay-based fix as wxutils/wxmapwindow.cpp "
+    "here before building this file" );
+
 DEFINE_EVENT_TYPE( WX_MAPWINDOW_POSITION );
 DEFINE_EVENT_TYPE( WX_MAPWINDOW_CLICKED );
 DEFINE_EVENT_TYPE( WX_MAPWINDOW_REPAINTED);

--- a/src/wxutils/wx_includes.hpp
+++ b/src/wxutils/wx_includes.hpp
@@ -9,6 +9,7 @@
 
 #include <wx/app.h>
 #include <wx/window.h>
+#include <wx/timer.h>
 
 #include <wx/dc.h>
 #include <wx/display.h>
@@ -16,6 +17,7 @@
 #include <wx/dcgraph.h>
 #include <wx/dcscreen.h>
 #include <wx/dcmemory.h>
+#include <wx/overlay.h>
 #include <wx/image.h>
 
 #include <wx/gdicmn.h>

--- a/src/wxutils/wxmapwindow.cpp
+++ b/src/wxutils/wxmapwindow.cpp
@@ -37,6 +37,8 @@ wxMapDragger::wxMapDragger()
     moveOriginOnShift = false;
     minDragLength = 10;
     dragMode = rbmRect;
+    dragCancelButton = wxMOUSE_BTN_NONE;
+    overlayResetPending = false;
 }
 
 wxMapDragger::~wxMapDragger()
@@ -105,8 +107,10 @@ void wxMapDragger::ProcessMouseEvent( wxMouseEvent &event )
 
         if( event.ButtonUp() )
         {
-            if( mapWindow )
-            {
+            if( event.GetButton() == dragCancelButton ) {
+                dragCancelButton = wxMOUSE_BTN_NONE;
+            }
+            else if( mapWindow ) {
                 mapWindow->ForwardMouseEvent( WX_MAPWINDOW_CLICKED, event  );
             }
         }
@@ -122,11 +126,14 @@ void wxMapDragger::ProcessMouseEvent( wxMouseEvent &event )
                 if( canDrag && InitDrag( event ) )
                 {
                     dragEndPoint = event.GetPosition();
-                    wxClientDC dc( mapWindow );
-                    dc.SetLogicalFunction( wxINVERT );
                     savedCursor = mapWindow->GetCursor();
                     SetDragCursor();
-                    DrawDragger( dc );
+                    {
+                        wxClientDC dc( mapWindow );
+                        wxDCOverlay dcOverlay( overlay, &dc );
+                        dcOverlay.Clear();
+                        DrawDragger( dc );
+                    }
                     mapWindow->CaptureMouse();
                     dragging = true;
                 }
@@ -139,10 +146,6 @@ void wxMapDragger::ProcessMouseEvent( wxMouseEvent &event )
     }
     else
     {
-        wxClientDC dc( mapWindow );
-        dc.SetLogicalFunction( wxINVERT );
-        DrawDragger( dc );
-
         // Button down events effectively cancel dragging, so can hit
         // second mouse button to cancel operation.
 
@@ -155,11 +158,23 @@ void wxMapDragger::ProcessMouseEvent( wxMouseEvent &event )
         {
             mapWindow->ReleaseMouse();
             dragging = false;
+            canDrag = false;
             mapWindow->SetCursor( savedCursor );
-            if( event.ButtonUp() ) EndDrag();
+            if( event.ButtonUp() ) {
+                dragCancelButton = wxMOUSE_BTN_NONE;
+                EndDrag();
+                // EndDrag() may have changed the view - wait for the next
+                // real repaint (see CheckPendingOverlayReset) before hiding
+                // the drag preview, rather than reveal stale content now.
+                overlayResetPending = true;
+            }
+            else {
+                dragCancelButton = event.GetButton();
+                // Nothing changed - safe to hide the drag preview right away.
+                overlay.Reset();
+            }
         }
-
-        if( dragging )
+        else
         {
             wxPoint newEndPoint = event.GetPosition();
 
@@ -171,6 +186,10 @@ void wxMapDragger::ProcessMouseEvent( wxMouseEvent &event )
                 dragStartPoint = wxPoint( dragStartPoint.x + dx, dragStartPoint.y + dy );
             }
             dragEndPoint = newEndPoint;
+
+            wxClientDC dc( mapWindow );
+            wxDCOverlay dcOverlay( overlay, &dc );
+            dcOverlay.Clear();
             DrawDragger( dc );
         }
     }
@@ -180,21 +199,37 @@ void wxMapDragger::ProcessMouseCaptureLostEvent(wxMouseCaptureLostEvent & WXUNUS
 {
     if( ! mapWindow ) return;
 
-    wxClientDC dc( mapWindow );
-    dc.SetLogicalFunction( wxINVERT );
-    DrawDragger( dc );
+    // No EndDrag() here - the view never changed, so unlike the end/cancel
+    // path in ProcessMouseEvent there's no pending repaint to wait for.
+    overlay.Reset();
 
     dragging = false;
     mapWindow->SetCursor( savedCursor );
 }
 
+void wxMapDragger::CheckPendingOverlayReset()
+{
+    if( overlayResetPending )
+    {
+        overlayResetPending = false;
+        // The real repaint has been issued, but may not be actually
+        // presented on screen yet - start a settle timer instead of
+        // resetting immediately, giving the compositor a margin to catch up.
+        // A compositor frame is typically ~16ms at 60Hz, so this should be
+        // several frames of margin - designed to reliably eliminate any
+        // repaint gap to the main window while still feeling responsive.
+        mapWindow->StartOverlayResetTimer( 50 );
+    }
+}
+
+void wxMapDragger::ResetOverlayNow()
+{
+    overlay.Reset();
+}
+
 void wxMapDragger::DrawDragger( wxDC &dc )
 {
-    if( dragMode == rbmLine )
-    {
-        dc.DrawLine( dragStartPoint, dragEndPoint );
-    }
-    else if( dragMode == rbmRect )
+    if( dragMode == rbmRect )
     {
         if( dragStartPoint == dragEndPoint )
         {
@@ -212,6 +247,22 @@ void wxMapDragger::DrawDragger( wxDC &dc )
             }
         }
     }
+}
+
+void wxMapDragger::PaintMapOnto( wxDC &dc )
+{
+    dc.SetBackground( wxBrush( mapWindow->GetBackgroundColour() ) );
+    dc.Clear();
+    mapWindow->PaintMap( dc );
+}
+
+wxBitmap wxMapDragger::CaptureMapBitmap()
+{
+    wxSize size = mapWindow->GetClientSize();
+    wxBitmap bitmap( size.GetWidth(), size.GetHeight() );
+    wxMemoryDC memDC( bitmap );
+    PaintMapOnto( memDC );
+    return bitmap;
 }
 
 
@@ -243,9 +294,31 @@ bool wxMapScaleDragger::InitDrag( const wxMouseEvent &event )
     else
     {
         SetMoveOriginOnShift( false );
-        SetRBDragMode( rbmLine );
+        panBitmap = CaptureMapBitmap();
     }
     return true;
+}
+
+void wxMapScaleDragger::DrawDragger( wxDC &dc )
+{
+    if( zoomMode == zdmPan )
+    {
+        // The shifted bitmap doesn't cover the whole window once dragged far
+        // enough - fill with the background colour first so the revealed
+        // edge shows plain background rather than the leftover, unshifted
+        // view.
+        dc.SetBackground( wxBrush( mapWindow->GetBackgroundColour() ) );
+        dc.Clear();
+        if( panBitmap.IsOk() )
+        {
+            wxPoint offset = dragEndPoint - dragStartPoint;
+            dc.DrawBitmap( panBitmap, offset.x, offset.y );
+        }
+    }
+    else
+    {
+        wxMapDragger::DrawDragger( dc );
+    }
 }
 
 void wxMapScaleDragger::SetDragCursor()
@@ -288,6 +361,7 @@ void wxMapScaleDragger::EndDrag()
         }
         scale.ZoomTo( newWindow );
     }
+    panBitmap = wxBitmap();
 }
 
 void wxMapScaleDragger::SetZoomDragMode( ZoomDragMode newMode )
@@ -325,6 +399,19 @@ void wxMapWindow::SetupMapWindow()
     map = 0;
     symbology = 0;
     sendPositionEvent = false;
+    overlayResetTimer.SetOwner( this );
+}
+
+void wxMapWindow::StartOverlayResetTimer( int delayMilliseconds )
+{
+    overlayResetTimer.StartOnce( delayMilliseconds );
+}
+
+void wxMapWindow::OnOverlayResetTimer( wxTimerEvent & WXUNUSED(event) )
+{
+    if( dragger ) {
+        dragger->ResetOverlayNow();
+    }
 }
 
 
@@ -342,6 +429,7 @@ BEGIN_EVENT_TABLE(wxMapWindow, wxWindow)
     EVT_SIZE( wxMapWindow::OnSizeEvent )
     EVT_SIMPLE_EVENT( WX_MAPWINDOW_SCALE_CHANGED, wxMapWindow::OnScaleChangeEvent )
     EVT_SIMPLE_EVENT( WX_MAPWINDOW_REDRAWMAP, wxMapWindow::OnRedrawMap )
+    EVT_TIMER( wxID_ANY, wxMapWindow::OnOverlayResetTimer )
 END_EVENT_TABLE()
 
 void wxMapWindow::SetDragger( wxMapDragger *newDragger )
@@ -412,7 +500,25 @@ void wxMapWindow::OnSizeEvent( wxSizeEvent & WXUNUSED(event) )
 
 void wxMapWindow::OnScaleChangeEvent( wxSimpleEvent & WXUNUSED(event) )
 {
+    RefreshCursorPosition();
     DoRedrawMap();
+}
+
+void wxMapWindow::RefreshCursorPosition()
+{
+    // A zoom/pan changes the scale without the mouse moving, so the position
+    // readout (only ever recomputed from a real mouse event) would otherwise
+    // keep showing the coordinate under the old scale until the next move.
+    if( ! scale.IsValid() ) return;
+
+    wxPoint mousePoint = ScreenToClient( wxGetMousePosition() );
+    scale.PlotToWorld( mousePoint, cursorPosition );
+    if( sendPositionEvent )
+    {
+        wxMouseEvent mouseEvent( wxEVT_MOTION );
+        mouseEvent.SetPosition( mousePoint );
+        ForwardMouseEvent( WX_MAPWINDOW_POSITION, mouseEvent );
+    }
 }
 
 void wxMapWindow::OnRedrawMap( wxSimpleEvent & WXUNUSED(event) )
@@ -443,6 +549,9 @@ void wxMapWindow::PaintMap(  wxDC &dc )
         map->DrawMap( drawer );
         drawer.FlushMap();
         SetCursor( saved );
+    }
+    if( dragger ) {
+        dragger->CheckPendingOverlayReset();
     }
 }
 

--- a/src/wxutils/wxmapwindow.hpp
+++ b/src/wxutils/wxmapwindow.hpp
@@ -42,7 +42,7 @@ typedef void (wxEvtHandler::*wxMapWindowEventFunction)(wxMapWindowEvent&);
 
 // Modes for rubber band dragging
 
-enum RBDragMode { rbmNone, rbmLine, rbmRect };
+enum RBDragMode { rbmNone, rbmRect };
 enum ZoomDragMode { zdmNone, zdmZoom, zdmPan };
 
 // Options for rubber band dragging
@@ -76,6 +76,17 @@ protected:
     void SetMapCursor( const wxCursor &cursor );
     virtual void DrawDragger( wxDC &dc );
 
+    // Fills dc with the background colour, then draws a fresh copy of the
+    // map onto it - rather than reading back what's currently on screen
+    // (e.g. via wxClientDC::Blit), which is unreliable on wxGTK, and isn't
+    // meaningful at all under wx's native overlay backend (selected on
+    // Wayland sessions), which draws to a separate transparent layer
+    // instead of the real window.
+    void PaintMapOnto( wxDC &dc );
+
+    // As PaintMapOnto, but into an owned bitmap sized to the window.
+    wxBitmap CaptureMapBitmap();
+
     wxMapWindow *mapWindow;
     wxPoint dragStartPoint;
     wxPoint dragEndPoint;
@@ -85,15 +96,32 @@ private:
     void ProcessMouseEvent( wxMouseEvent &event );
     void ProcessMouseCaptureLostEvent( wxMouseCaptureLostEvent &event );
 
+    // Called by wxMapWindow::PaintMap() (a friend) right after it draws -
+    // if a reset was requested, starts a settle timer rather than resetting
+    // immediately, since the repaint may not be actually presented on
+    // screen yet even though it's just been issued.
+    void CheckPendingOverlayReset();
+
+    // Called by wxMapWindow once the settle timer fires - actually hides
+    // the drag preview.
+    void ResetOverlayNow();
+
     bool dragging;
     bool canDrag;  // Used to avoid repeated checks after a rejected drag start
     bool moveOriginOnShift;
+    bool overlayResetPending;
+
+    // Button whose up event should be swallowed rather than forwarded as a
+    // fresh click, because it only cancelled an in-progress drag
+    // (wxMOUSE_BTN_NONE if no such swallow is pending).
+    int dragCancelButton;
 
     int minDragLength;
 
     RBDragMode dragMode;
 
     wxCursor savedCursor;
+    wxOverlay overlay;
 };
 
 // Map scale dragger class
@@ -107,10 +135,19 @@ public:
     virtual void EndDrag();
     void SetZoomDragMode( ZoomDragMode newMode );
     void SetAutoZoomPanMode( bool newMode = true );
+protected:
+    // protected, not private: a subclass may need to call this base
+    // implementation directly (qualified, non-virtually) from within its
+    // own override, which requires at least protected access.
+    virtual void DrawDragger( wxDC &dc );
 private:
     void ZoomTo( const MapRect &newRect );
     ZoomDragMode zoomMode;
     bool autoZoomPanMode;
+
+    // Snapshot of the view taken when a pan drag starts, blitted at the
+    // current drag offset each frame for a live-scrolling preview.
+    wxBitmap panBitmap;
 };
 
 // Map window class
@@ -148,6 +185,14 @@ private:
     void OnScaleChangeEvent( wxSimpleEvent &event );
     void OnRedrawMap( wxSimpleEvent &event );
     void ForwardMouseEvent(  wxEventType type, const wxMouseEvent &event );
+    void RefreshCursorPosition();
+    void OnOverlayResetTimer( wxTimerEvent &event );
+
+    // Starts a one-shot timer that calls dragger->ResetOverlayNow() after
+    // delayMilliseconds - the repaint that made this necessary may have
+    // been issued but not yet actually presented on screen, so this gives
+    // it a margin to catch up before the drag preview is hidden.
+    void StartOverlayResetTimer( int delayMilliseconds );
 
     wxMap *map;
     wxMapScale scale;
@@ -155,6 +200,7 @@ private:
     wxMapDragger *dragger;
     MapPoint cursorPosition;
     bool sendPositionEvent;
+    wxTimer overlayResetTimer;
 
     DECLARE_DYNAMIC_CLASS( wxMapWindow );
     DECLARE_EVENT_TABLE();


### PR DESCRIPTION
## Summary

The zoom rectangle's XOR-invert drawing technique silently fails to render on wxGTK3, especially under Wayland — replaced with `wxOverlay`-based drawing.

Pan mode used the same XOR technique for its guide line. That wasn't broken by this bug, but was a plain from-to line rather than a real preview — replaced with a shifted-bitmap preview (one snapshot per pan, repositioned per frame — not a per-frame re-render).

## What changed

- **Zoom rectangle**: switched from `wxClientDC` + `SetLogicalFunction(wxINVERT)` (broken on wxGTK3/Wayland) to `wxOverlay`/`wxDCOverlay`-based drawing.
- **Pan preview**: now a shifted-bitmap preview — one snapshot captured per pan, at drag start, via a fresh render (not a screen read-back, which is unreliable on wxGTK), then cheaply repositioned each frame rather than re-rendering the underlying data on every frame (which would scale with dataset size and could lag on large networks). Backed by the map's background colour at the revealed edge.
- **Drag-preview teardown timing**: hiding the preview at the end of a drag is deferred until a real repaint has both happened and had a 50ms margin to actually reach the screen, avoiding a visible flash of stale content — determined empirically, since neither an immediate reset nor deferring via `CallAfter` proved reliable.
- **Two related pre-existing bugs fixed along the way**:
  - Cancelling a drag with a second mouse button left state that could spuriously restart a new drag, or misfire that button's next click as a real click (e.g. triggering an unrelated zoom).
  - The position readout didn't refresh after a zoom/pan until the next mouse move.
- **`wxtest/wxmapwindow.cpp`**: a dead, CMake-unreferenced duplicate of the fixed code, still with the old bug — added a `static_assert` so it fails loudly if anyone ever builds it again, instead of silently reintroducing this.

## Testing

Verified empirically on three environments:

- **GTK3 + Wayland** (via WSLg). Both the zoom rectangle and the pan preview were tested through several iterations before landing on a working fix, including the end-of-drag settle timing (no visible flash of stale content after a pan completes).
- **GTK3 + X11** (non-Wayland GTK3 session) - tested by @ccrook, working.
- **Windows** (sandbox) - tested directly, working.

**Not tested — assumed to behave the same, not verified:**

- **wx 3.0.x** (Jammy's `libwxgtk3.0-gtk3-dev`). Checked against wx 3.2 source only (both the vendored Windows 3.2.4 tree and the installed Linux 3.2.9 headers); the `wxOverlay`/`wxDCOverlay` API has been unchanged since 2006, so 3.0.x should have the same generic-backend behaviour, but no actual 3.0.x source or build was available to confirm.

[GSR-982](https://toitutewhenua.atlassian.net/browse/GSR-982)

[GSR-982]: https://toitutewhenua.atlassian.net/browse/GSR-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ