### PR TITLE
feat: cross-compile SNAP for Windows with MinGW-w64

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,8 +2,8 @@ BUILD INSTRUCTIONS
 ==================
 
 
-Build instructions Windows
-==========================
+Build instructions on Windows - MSVC
+====================================
 
 Only 64-bit builds are supported.
 
@@ -73,7 +73,85 @@ NSIS must be installed for the `.exe` target: https://nsis.sourceforge.io/
 
 The GUI programs (snap_manager, snapadjust, snapplot) are disabled by default on Windows.
 Building them requires wxWidgets — see `wxwidgets\README.md` for instructions.
-Once wxWidgets is built, re-configure with `-DSNAP_BUILD_GUI=ON`.
+
+Once wxWidgets is built, set the `WXWIN` environment variable to the extracted wxWidgets
+source root (e.g. `set WXWIN=<repo>\wxwidgets\wxWidgets`), then build with one of the
+`-gui` presets:
+
+```
+cmake --preset windows-msvc-release-gui
+cmake --build --preset windows-msvc-release-gui
+```
+
+Build instructions for Windows - MinGW-w64 cross-compile (from Linux)
+=======================================================================
+
+Windows binaries can also be built entirely from a Linux (or WSL) host using the
+MinGW-w64 cross-compiler, without needing Visual Studio at all.
+
+**Prerequisites**
+
+1. **MinGW-w64 cross-compiler** — `sudo apt-get install g++-mingw-w64-x86-64`
+2. **7zip** — `sudo apt-get install 7zip` (to extract the vendored wxWidgets archive;
+   only needed for the GUI targets)
+3. **NSIS** — `sudo apt-get install nsis` (only needed for packaging)
+4. **Boost**, cross-built for MinGW. Reuse an existing Boost source tree if you have
+   one already (no need to re-download), or fetch a fresh one from
+   https://www.boost.org/users/download/, then from the Boost source root:
+   ```
+   cat > user-config.jam <<'EOF'
+   using gcc : 13 : x86_64-w64-mingw32-g++ ;
+   EOF
+   ./bootstrap.sh
+   ./b2 --user-config=$(pwd)/user-config.jam toolset=gcc-13 target-os=windows \
+     address-model=64 architecture=x86 link=static runtime-link=static \
+     threading=multi variant=release \
+     --with-filesystem --with-regex --with-system --stagedir=stage-mingw -j$(nproc)
+   ```
+   Replace `13` with the major GCC version of your installed
+   `g++-mingw-w64-x86-64` (check with `x86_64-w64-mingw32-g++ --version`) - the
+   toolset name field must be a numeric-parseable tag, not an arbitrary word.
+
+   Set `BOOST_ROOT` to this Boost source root.
+5. **wxWidgets**, cross-built for MinGW (only needed for the GUI targets). wx's own
+   Windows makefile (`wxwidgets\build\msw\makefile.gcc`) is `cmd.exe`-only and does
+   not work for cross-compiling from Linux - use wx's autotools `configure` build
+   instead, which is designed for exactly this:
+   ```
+   cd wxwidgets
+   mkdir wxWidgets_mingw && 7z x wxWidgets-3.2.4.7z -owxWidgets_mingw
+   mkdir wx-mingw-build && cd wx-mingw-build
+   ../wxWidgets_mingw/configure --host=x86_64-w64-mingw32 --build=x86_64-linux-gnu \
+     --disable-shared --enable-unicode --prefix=$(pwd)/install
+   make -j$(nproc)
+   ```
+   Set `WX_MINGW_CONFIG` to the generated `wxwidgets/wx-mingw-build/wx-config` script.
+
+**Building**
+
+Either use `build.py --mingw` (see below), or invoke the presets directly:
+
+```
+cmake --preset windows-mingw-release-gui
+cmake --build --preset windows-mingw-release-gui
+```
+
+(Use `windows-mingw-release` instead for a non-GUI build.) Binaries are placed in
+`build/windows-mingw-release[-gui]/src/`.
+
+Using `build.py`:
+
+```
+python3 build.py release all --mingw
+python3 build.py release package --mingw   # ZIP + NSIS installer, via cpack
+```
+
+`--no-gui` skips the GUI targets (and the `WX_MINGW_CONFIG` requirement). Only the
+`release` type and the `all`/`package`/`clean` targets are supported with `--mingw` -
+`snap_cmd`/`test`/`install` don't apply to a cross-compiled Windows build.
+
+Coordinate system data and packaging otherwise work the same way as the MSVC build
+above (`COORDSYSDEF`, `cpack`).
 
 Build instructions for Linux
 ============================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,18 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # ── Compiler flags ────────────────────────────────────────────────────────────
+if(WIN32)
+    # Static-link everything on Windows, so the built exe has no dependency on
+    # a redistributable (MSVC runtime / MinGW's libgcc+libstdc++) on the
+    # target machine. Mechanism differs per compiler; the goal is shared.
+    if(MSVC)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    else()
+        add_link_options(-static-libgcc -static-libstdc++ -static)
+    endif()
+endif()
+
 if(MSVC)
-    # Match wxWidgets' RUNTIME_LIBS=static build (/MT) so the exe has no
-    # dependency on the MSVC redistributable on the target machine.
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
     add_compile_options(/W4 /wd4244)
     add_compile_definitions(
         _CRT_SECURE_NO_WARNINGS
@@ -50,9 +58,12 @@ else()
         add_link_options(-lefence)
     endif()
 
-    # CMake injects -DNDEBUG automatically for Release; Profile needs it added
+    # CMake injects -DNDEBUG automatically for Release; Profile needs it added.
+    # UNIX is only correct for an actual Unix target - a non-MSVC compiler
+    # (e.g. MinGW) targeting Windows must not get it, or it contradicts
+    # snapconfig.h's own _WIN32/_MSC_VER platform check.
     add_compile_definitions(
-        UNIX
+        $<$<NOT:$<BOOL:${WIN32}>>:UNIX>
         $<$<CONFIG:Debug>:CHECKBLT>
         $<$<CONFIG:Profile>:NDEBUG>)
 endif()
@@ -75,6 +86,10 @@ endif()
 # the 'mt-s' variants rather than the default 'mt' (/MD) variants.
 if(MSVC)
     set(Boost_USE_STATIC_RUNTIME ON)
+elseif(WIN32)
+    # MinGW: only a static (runtime-link=static), untagged build is staged,
+    # so there's no 'mt'/'mt-s' variant choice to make - just select static.
+    set(Boost_USE_STATIC_LIBS ON)
 endif()
 find_package(Boost REQUIRED COMPONENTS filesystem regex)
 # boost::system is header-only since Boost 1.69; newer distros ship no .so for it.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -53,11 +53,38 @@
         "wxWidgets_USE_REL_AND_DBG": "OFF"
       }
     }
+    ,
+    {
+      "name": "windows-mingw-release",
+      "displayName": "Windows x64 Release (MinGW-w64 cross-compile)",
+      "generator": "Unix Makefiles",
+      "toolchainFile": "${sourceDir}/cmake/toolchain-mingw-w64.cmake",
+      "binaryDir": "${sourceDir}/build/windows-mingw-release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "BOOST_ROOT": "$env{BOOST_ROOT}",
+        "BOOST_LIBRARYDIR": "$env{BOOST_ROOT}/stage-mingw/lib",
+        "Boost_NO_SYSTEM_PATHS": "ON",
+        "SNAP_BUILD_GUI": "OFF"
+      }
+    },
+    {
+      "name": "windows-mingw-release-gui",
+      "displayName": "Windows x64 Release with GUI (MinGW-w64 cross-compile)",
+      "inherits": "windows-mingw-release",
+      "binaryDir": "${sourceDir}/build/windows-mingw-release-gui",
+      "cacheVariables": {
+        "SNAP_BUILD_GUI": "ON",
+        "wxWidgets_CONFIG_EXECUTABLE": "$env{WX_MINGW_CONFIG}"
+      }
+    }
   ],
   "buildPresets": [
     {"name": "windows-msvc-debug", "configurePreset": "windows-msvc-debug"},
     {"name": "windows-msvc-release", "configurePreset": "windows-msvc-release"},
     {"name": "windows-msvc-debug-gui", "configurePreset": "windows-msvc-debug-gui"},
-    {"name": "windows-msvc-release-gui", "configurePreset": "windows-msvc-release-gui"}
+    {"name": "windows-msvc-release-gui", "configurePreset": "windows-msvc-release-gui"},
+    {"name": "windows-mingw-release", "configurePreset": "windows-mingw-release"},
+    {"name": "windows-mingw-release-gui", "configurePreset": "windows-mingw-release-gui"}
   ]
 }

--- a/build.py
+++ b/build.py
@@ -15,7 +15,8 @@ TARGET (default: all):
     snap_cmd   Build command-line tools only
     test       Build snap_cmd and run regression tests
     install    Build all and install to system
-    package    Build a Debian package (Linux, release only; --build-dir sets SNAP_BUILD_DIR)
+    package    Build a Debian package (Linux, release only; --build-dir sets SNAP_BUILD_DIR),
+               or a Windows ZIP/NSIS package with --mingw (release only)
     clean      Remove the build directory
 
 Options:
@@ -24,6 +25,13 @@ Options:
     --build-dir DIR  Build output directory (default: build-{type}); for package,
                      sets SNAP_BUILD_DIR passed to debuild/debian/rules
     --no-efence      Do not link efence (debug builds link efence by default)
+    --mingw          Cross-compile for Windows using MinGW-w64 (from Linux only;
+                     release only). Requires BOOST_ROOT set to a MinGW-built Boost
+                     tree, and (unless --no-gui) WX_MINGW_CONFIG set to a MinGW-built
+                     wxWidgets wx-config script - see BUILD.md. Uses the
+                     windows-mingw-release[-gui] CMake presets rather than the plain
+                     -D flags used for the native Linux build; snap_cmd/test/install
+                     targets are not supported with --mingw.
 """
 
 from __future__ import annotations
@@ -135,6 +143,46 @@ def run_tests(build_type: str) -> None:
     run(["perl", testall, "-e"] + (["-r"] if build_type == "release" else []))
 
 
+def mingw_build(args) -> None:
+    if platform.system() != "Linux":
+        print("ABORTED: --mingw cross-compiles for Windows and is only supported "
+              "when run from Linux")
+        sys.exit(1)
+    if args.type != "release":
+        print("ABORTED: --mingw only supports the release build type")
+        sys.exit(1)
+    if args.target not in ("all", "package", "clean"):
+        print(f"ABORTED: --mingw does not support the '{args.target}' target "
+              "(snap_cmd/test/install don't apply to a cross-compiled Windows build)")
+        sys.exit(1)
+
+    preset = "windows-mingw-release" if args.no_gui else "windows-mingw-release-gui"
+    build_d = os.path.join(REPO_ROOT, "build", preset)
+
+    if args.target == "clean":
+        if os.path.exists(build_d):
+            print(f"Removing {build_d}")
+            shutil.rmtree(build_d)
+        return
+
+    if not os.environ.get("BOOST_ROOT"):
+        print("ABORTED: BOOST_ROOT must be set to a MinGW-built Boost tree - see BUILD.md")
+        sys.exit(1)
+    if not args.no_gui and not os.environ.get("WX_MINGW_CONFIG"):
+        print("ABORTED: WX_MINGW_CONFIG must be set to a MinGW-built wxWidgets "
+              "wx-config script (or pass --no-gui) - see BUILD.md")
+        sys.exit(1)
+
+    run(["cmake", "--preset", preset])
+    build_cmd = ["cmake", "--build", "--preset", preset]
+    if args.jobs:
+        build_cmd += ["--parallel", str(args.jobs)]
+    run(build_cmd)
+
+    if args.target == "package":
+        run(["cpack"], cwd=build_d)
+
+
 def check_committed() -> None:
     result = subprocess.run(["git", "diff", "--quiet", "HEAD"], cwd=REPO_ROOT, check=False)
     if result.returncode != 0:
@@ -171,7 +219,14 @@ def main() -> None:
                         help="Build output directory (default: build-{type})")
     parser.add_argument("--no-efence", action="store_true",
                         help="Do not link efence (debug builds link efence by default)")
+    parser.add_argument("--mingw", action="store_true",
+                        help="Cross-compile for Windows using MinGW-w64 (Linux host, "
+                             "release only) - see BUILD.md")
     args = parser.parse_args()
+
+    if args.mingw:
+        mingw_build(args)
+        return
 
     build_d = args.build_dir if args.build_dir else build_dir(args.type)
     efence = (args.type == "debug") and not args.no_efence

--- a/cmake/toolchain-mingw-w64.cmake
+++ b/cmake/toolchain-mingw-w64.cmake
@@ -1,0 +1,15 @@
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_RC_COMPILER x86_64-w64-mingw32-windres)
+
+set(CMAKE_FIND_ROOT_PATH /usr/x86_64-w64-mingw32)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# BOTH, not ONLY: dependencies like Boost are cross-built outside the mingw
+# sysroot (see BOOST_ROOT), so restricting library/include search to the
+# sysroot alone would make CMake unable to find them at all.
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)

--- a/src/concord/concord.cpp
+++ b/src/concord/concord.cpp
@@ -9,7 +9,7 @@
 #include <math.h>
 #include "util/snapctype.h"
 
-#if defined( _MSC_VER )
+#if defined( _WIN32 )
 #include <conio.h>
 #include <io.h>
 #else

--- a/src/snaplib/dbl4/dbl4_utl_blob.cpp
+++ b/src/snaplib/dbl4/dbl4_utl_blob.cpp
@@ -71,7 +71,7 @@ StatusType utlCreateBlobHandle( DBHandle conn, hBlob * blob, Boolean blnOutput)
         if( ! (*blob)->buffer )
             THROW_EXCEPTION("utlCreateBlobHandle: Memory allocation failure");
     }
-    TRACE_BLBMGMT(("utlCreateBlobHandle: Blob created with handle %ld",(long) (*blob) ));
+    TRACE_BLBMGMT(("utlCreateBlobHandle: Blob created with handle %llX",reinterpret_cast<unsigned long long>(*blob) ));
     return STS_OK;
 }
 
@@ -91,7 +91,7 @@ StatusType utlCreateBlobHandle( DBHandle conn, hBlob * blob, Boolean blnOutput)
 
 StatusType utlBlobClose( hBlob blob)
 {
-    TRACE_BLBMGMT(("utlBlobClose: Blob closed with handle %ld",(long) (blob) ));
+    TRACE_BLBMGMT(("utlBlobClose: Blob closed with handle %llX",reinterpret_cast<unsigned long long>(blob) ));
     if( blob->pvBlob )
     {
         utlReleaseBlobDB( blob->pvBlob );
@@ -121,8 +121,8 @@ StatusType utlBlobClose( hBlob blob)
 StatusType utlBlobReadAt( hBlob blob, long lngOffset, long lngBufSize,
                           void * pvBuffer)
 {
-    TRACE_BLBREAD(("utlBlobReadAt: Blob read - handle %ld offset %ld bytes %ld",
-                   (long) (blob), lngOffset, lngBufSize ));
+    TRACE_BLBREAD(("utlBlobReadAt: Blob read - handle %llX offset %ld bytes %ld",
+                   reinterpret_cast<unsigned long long>(blob), lngOffset, lngBufSize ));
     if( blob->pvBlob )
     {
         utlReadBlobDB( blob->pvBlob, lngOffset, lngBufSize, pvBuffer );
@@ -152,7 +152,7 @@ StatusType utlBlobReadAt( hBlob blob, long lngOffset, long lngBufSize,
 
 StatusType utlBlobWrite( hBlob blob, long lngBufSize, void *buffer)
 {
-    TRACE_BLBREAD(("utlBlobWrite: Blob write - handle %ld",(long) (blob) ));
+    TRACE_BLBREAD(("utlBlobWrite: Blob write - handle %llX",reinterpret_cast<unsigned long long>(blob) ));
     if( blob->pvBlob )
     {
         utlWriteBlobDB( blob->pvBlob, lngBufSize, buffer);
@@ -183,7 +183,7 @@ StatusType utlBlobWrite( hBlob blob, long lngBufSize, void *buffer)
 
 StatusType utlBlobSeek( hBlob blob, long position, int whence)
 {
-    TRACE_BLBREAD(("utlBlobSeek: Blob handle %ld",(long) (blob) ));
+    TRACE_BLBREAD(("utlBlobSeek: Blob handle %llX",reinterpret_cast<unsigned long long>(blob) ));
     if( blob->pvBlob )
     {
         utlSeekBlobDB( blob->pvBlob, position, whence );
@@ -212,7 +212,7 @@ StatusType utlBlobSeek( hBlob blob, long position, int whence)
 
 StatusType utlBlobTell( hBlob blob, long *position)
 {
-    TRACE_BLBREAD(("utlBlobTell: Blob handle %ld",(long) (blob) ));
+    TRACE_BLBREAD(("utlBlobTell: Blob handle %llX",reinterpret_cast<unsigned long long>(blob) ));
     if( blob->pvBlob )
     {
         utlTellBlobDB( blob->pvBlob, position );
@@ -249,7 +249,7 @@ StatusType utlBlobTell( hBlob blob, long *position)
 
 StatusType utlBlobPrintf( hBlob blob, char *format, ... )
 {
-    TRACE_BLBREAD(("utlBlobPrintf: Blob handle %ld",(long) (blob) ));
+    TRACE_BLBREAD(("utlBlobPrintf: Blob handle %llX",reinterpret_cast<unsigned long long>(blob) ));
     if( blob->buffer && blob->pvBlob )
     {
         va_list ap;

--- a/src/snaplib/dbl4/dbl4_utl_trig.cpp
+++ b/src/snaplib/dbl4/dbl4_utl_trig.cpp
@@ -772,7 +772,7 @@ StatusType utlCreateTrig( hBinSrc binsrc, hTrig *trig)
     *trig = 0;
     sts = create_trig_def( &def, binsrc );
     if( sts == STS_OK ) *trig =  (void *) def;
-    TRACE_TRIG(("utlCreateTrig %lX",(unsigned long) *trig));
+    TRACE_TRIG(("utlCreateTrig %llX",reinterpret_cast<unsigned long long>(*trig)));
     return sts;
 }
 
@@ -792,7 +792,7 @@ StatusType utlCreateTrig( hBinSrc binsrc, hTrig *trig)
 StatusType utlReleaseTrig( hTrig trig)
 {
     hTrigDef def;
-    TRACE_TRIG(("utlReleaseTrig %lX",(unsigned long) trig));
+    TRACE_TRIG(("utlReleaseTrig %llX",reinterpret_cast<unsigned long long>(trig)));
     def = trig_def_from_handle( trig );
     if( ! def ) RETURN_STATUS(STS_INVALID_HANDLE);
     delete_trig_def(def);
@@ -912,7 +912,7 @@ StatusType utlCalcTrig( hTrig trig, double x, double y, double *value)
     def = trig_def_from_handle( trig );
     if( ! def ) RETURN_STATUS(STS_INVALID_HANDLE);
 
-    TRACE_TRIG(("utlCalcTrig: %lX %lf %lf",(unsigned long) trig,x,y));
+    TRACE_TRIG(("utlCalcTrig: %llX %lf %lf",reinterpret_cast<unsigned long long>(trig),x,y));
 
     sts = calc_triangle_value( def, x, y, value );
 

--- a/src/snaplib/snapconfig.h
+++ b/src/snaplib/snapconfig.h
@@ -50,7 +50,16 @@
 #else
 #define CONFIGURE_EXPONENT()
 #endif
+// _set_printf_count_output enables %n support in MSVC/UCRT's printf, and is
+// only ever declared (and exported) there - MinGW's own printf engine (used
+// when __USE_MINGW_ANSI_STDIO is set, and its msvcrt-target import library
+// doesn't even export the symbol regardless) supports %n unconditionally,
+// so this is a no-op for anything other than real MSVC.
+#if defined(_MSC_VER)
 #define CONFIGURE_PRINTF() _set_printf_count_output(1)
+#else
+#define CONFIGURE_PRINTF()
+#endif
 #endif
 
 #define CONFIGURE_RUNTIME() CONFIGURE_PRINTF(); CONFIGURE_EXPONENT()

--- a/src/snaplib/util/binfile.cpp
+++ b/src/snaplib/util/binfile.cpp
@@ -27,7 +27,7 @@
 #include "util/binfile.h"
 #include "util/errdef.h"
 
-#ifdef _MSC_VER
+#ifdef _WIN32
 #define MS_LOCKING
 #endif
 

--- a/src/snaplib/util/fileutil.cpp
+++ b/src/snaplib/util/fileutil.cpp
@@ -16,8 +16,13 @@
 #include <stdlib.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#ifdef _MSC_VER
+#ifdef _WIN32
 #include <io.h>
+#include <fcntl.h>
+#include <share.h>
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
 #endif
 #ifdef UNIX
 #define _stat stat
@@ -678,6 +683,20 @@ const char *find_file( const char *name, const char *dflt_ext, const char *relat
     }
     return spec;
 }
+
+#ifdef _WIN32
+FILE *snaptmpfile()
+{
+    char tmpdir[MAX_PATH];
+    char tmpname[MAX_PATH];
+    if( ! GetTempPathA( MAX_PATH, tmpdir ) ) return NULL;
+    if( ! GetTempFileNameA( tmpdir, "snp", 0, tmpname ) ) return NULL;
+    int fd = _sopen( tmpname, _O_RDWR | _O_CREAT | _O_TRUNC | _O_BINARY | _O_TEMPORARY,
+                      _SH_DENYRW, _S_IREAD | _S_IWRITE );
+    if( fd == -1 ) return NULL;
+    return _fdopen( fd, "w+b" );
+}
+#endif
 
 int skip_utf8_bom( FILE *f )
 {

--- a/src/snaplib/util/fileutil.h
+++ b/src/snaplib/util/fileutil.h
@@ -128,7 +128,15 @@ const char *find_file( const char *name, const char *dflt_ext, const char *base,
 
 /* Create a temporary file, and set up a handler to delete it when the program terminates */
 
+#ifdef _WIN32
+/* The standard tmpfile() creates the file in the root of the current drive,
+   which a non-administrator Windows account often cannot write to. Use a
+   proper scratch-file implementation based on the actual temp directory
+   (TMP/TEMP/USERPROFILE) instead. */
+FILE *snaptmpfile();
+#else
 #define snaptmpfile tmpfile
+#endif
 
 /* Skip unicode BOM (byte order marker).  Assumes file pointer is set to beginning of file */
 /* Returns 1 if successful (UTF8 or no BOM), 0 if UTF16 BOM at start of file */


### PR DESCRIPTION
## Summary

Adds a MinGW-w64 cross-compilation path for building SNAP on Windows, as an
alternative to the existing MSVC build - lets Windows binaries be produced
entirely from a Linux (or WSL) host without needing Visual Studio at all.

Also fixes two genuine pre-existing bugs surfaced while testing this path,
both of which affect the existing MSVC build too:

- **Pointer-to-integer truncation** in `dbl4_utl_blob.cpp`/`dbl4_utl_trig.cpp`'s
  debug trace logging. 64-bit Windows uses LLP64 (`long` is 32 bits despite
  64-bit pointers), so casting a pointer to `(long)` silently truncated it
  under MSVC (just a warning) - purely diagnostic trace-log output, gated by
  the `XATRACE` env var, not affecting any blob I/O or file format. Fixed with
  `reinterpret_cast<unsigned long long>`.
- **`snaptmpfile()` (aliased to `tmpfile()`) writes scratch files to the root
  of the current drive on Windows** - often unwritable for a non-administrator
  account, causing "Cannot open scratch file" failures (e.g. snapplot's
  connection list). Fixed with a real Windows implementation using
  `GetTempPath`/`GetTempFileName` to pick an actually-writable directory.

## What's new

- `cmake/toolchain-mingw-w64.cmake` + new `windows-mingw-release[-gui]` CMake
  presets.
- `CMakeLists.txt`: unified the "static link, no redistributable dependency"
  intent into one `WIN32` block covering both MSVC and MinGW. Fixed a bug
  where the non-MSVC branch unconditionally defined `UNIX` - wrong for any
  non-MSVC *Windows* compiler.
- Four `_MSC_VER` checks widened to `_WIN32` so MinGW takes the same code
  paths as MSVC.
- `CONFIGURE_PRINTF()`'s `_set_printf_count_output` call scoped to real MSVC
  only - MinGW's own printf engine supports `%n` unconditionally and doesn't
  export this UCRT-only symbol.
- `build.py --mingw` flag wrapping the new presets (release-only;
  `all`/`package`/`clean` targets only).
- `BUILD.md`: new top-level MinGW cross-compile section (prerequisites,
  Boost/wxWidgets cross-build steps, usage), existing MSVC section retitled
  for clarity, and a pre-existing `WXWIN` documentation gap fixed for the
  MSVC GUI build too.

## Test plan

- [x] Linux: full regression suite passes (694 tests, incl. binroundtrip)
- [x] MinGW: non-GUI and GUI builds both compile and link cleanly
- [x] MinGW: `snap.exe` run against a real regression test vector, output
      matches the native Linux build exactly
- [x] MinGW: `snapplot.exe` launched for real, opens correctly, renders a
      dialog, closes normally
- [x] MinGW: packaging (`cpack` → ZIP + NSIS installer) works entirely from
      Linux; verified binaries have no MinGW runtime DLL dependencies
      (`libgcc_s`/`libstdc++-6`/`libwinpthread-1`) - only standard OS DLLs
- [x] MSVC: rebuilt in Windows Sandbox after pulling this branch; `snap` and
      `snapplot` both ran correctly

[GSR-983](https://toitutewhenua.atlassian.net/browse/GSR-983)

[GSR-983]: https://toitutewhenua.atlassian.net/browse/GSR-983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ