### PR TITLE
fix: snapplot silently failed to report an incompatible binary file version

### DIFF
--- a/src/snaplib/util/binfile.cpp
+++ b/src/snaplib/util/binfile.cpp
@@ -99,7 +99,7 @@ BINARY_FILE *create_binary_file( char *fname, const char *signature )
 }
 
 
-BINARY_FILE *open_binary_file( char *fname, const char *signature )
+BinFileOpenOutcome open_binary_file( char *fname, const char *signature )
 {
     FILE *f = NULL;
     BINARY_FILE *b;
@@ -133,7 +133,7 @@ BINARY_FILE *open_binary_file( char *fname, const char *signature )
 #else
     f = fopen( fname, "rb" );
 #endif
-    if( !f ) return NULL;
+    if( !f ) return { NULL, BinFileOpenResult::NotFound };
 
     nsig = strlen(signature) + strlen(SIG_TRAILER);
 
@@ -144,7 +144,7 @@ BINARY_FILE *open_binary_file( char *fname, const char *signature )
     {
         check_free( sig );
         fclose(f);
-        return NULL;
+        return { NULL, BinFileOpenResult::InvalidVersion };
     }
 
     check_free( sig );
@@ -161,7 +161,7 @@ BINARY_FILE *open_binary_file( char *fname, const char *signature )
     b->sigchar = 0;
     find_section(b,VERSION_SECTION);
     b->bf_version = b->section_version;
-    return b;
+    return { b, BinFileOpenResult::Ok };
 }
 
 

--- a/src/snaplib/util/binfile.h
+++ b/src/snaplib/util/binfile.h
@@ -36,8 +36,16 @@ typedef struct
 } BINARY_FILE;
 
 
+enum class BinFileOpenResult { NotFound, InvalidVersion, Ok };
+
+struct BinFileOpenOutcome
+{
+    BINARY_FILE *file;
+    BinFileOpenResult result;
+};
+
 BINARY_FILE *create_binary_file( char *fname, const char *header );
-BINARY_FILE *open_binary_file( char *fname, const char *header );
+BinFileOpenOutcome open_binary_file( char *fname, const char *header );
 void close_binary_file( BINARY_FILE *bin );
 void create_section_ex( BINARY_FILE *bin, const char *section, long version );
 void create_section( BINARY_FILE *bin, const char *section );

--- a/src/snaplib/util/errdef.h
+++ b/src/snaplib/util/errdef.h
@@ -44,10 +44,18 @@
 #define MEM_ALLOC_ERROR  65
 #define INTERNAL_ERROR   66
 
+/* Orthogonal modifier bit, ORed onto a severity above (e.g.
+   WARNING_ERROR | SHOW_DIALOG) - not a severity/condition itself. Lets a
+   caller explicitly ask for a warning to be shown as a dialog in GUI
+   programs that support it, rather than only logged, without changing
+   default behaviour for every other (unaudited) warning call site. */
+#define SHOW_DIALOG      128
+
 #define REPORTABLE_ERROR(sts)        ((sts) & (INFO_ERROR | WARNING_ERROR | FATAL_ERROR))
 #define INFO_ERROR_CONDITION(sts)    (((sts) & INFO_ERROR) && !((sts) & (FATAL_ERROR | WARNING_ERROR)))
 #define FATAL_ERROR_CONDITION(sts)    ((sts) & FATAL_ERROR)
 #define WARNING_ERROR_CONDITION(sts)  ((sts) & WARNING_ERROR)
+#define SHOW_DIALOG_CONDITION(sts)    ((sts) & SHOW_DIALOG)
 
 /* Define a default error handler - takes three parameters,
    1) An integer error status

--- a/src/snaplist/snaplist.cpp
+++ b/src/snaplist/snaplist.cpp
@@ -1101,7 +1101,7 @@ int main( int argc, char *argv[] )
     install_default_crdsys_file( );
 
     bfn = argv[1];
-    b = open_binary_file( bfn, BINFILE_SIGNATURE );
+    b = open_binary_file( bfn, BINFILE_SIGNATURE ).file;
 
     if( !b ||
             reload_snap_globals( b ) != OK ||

--- a/src/snapplot/plotbin.cpp
+++ b/src/snapplot/plotbin.cpp
@@ -59,9 +59,20 @@ int reload_binary_data( )
     memcpy( bfn, root_name, nch );
     strcpy( bfn+nch, BINFILE_EXT );
 
-    b = open_binary_file( bfn, BINFILE_SIGNATURE );
+    auto [file, result] = open_binary_file( bfn, BINFILE_SIGNATURE );
+    b = file;
 
-    if( !b ) { free(bfn); return NO_MORE_DATA;}
+    if( !b )
+    {
+        if( result == BinFileOpenResult::InvalidVersion )
+        {
+            handle_error( WARNING_ERROR | SHOW_DIALOG,
+                          "Cannot reload data - binary file version is not compatible with this version of SNAP",
+                          bfn );
+        }
+        free(bfn);
+        return NO_MORE_DATA;
+    }
 
     print_log("     Reloading data from binary file...\n");
 
@@ -72,7 +83,7 @@ int reload_binary_data( )
             reload_parameters( b ) != OK )
     {
 
-        handle_error( FILE_OPEN_ERROR, "Cannot reload data from binary file",
+        handle_error( FILE_OPEN_ERROR | SHOW_DIALOG, "Cannot reload data from binary file",
                       bfn);
         sts = FILE_READ_ERROR;
     }

--- a/src/snapplot/snapplot_load.cpp
+++ b/src/snapplot/snapplot_load.cpp
@@ -244,7 +244,7 @@ int snapplot_load( int argc, char *argv[] )
         {
             if( add_configuration_file( filelist[i] ) != OK )
             {
-                handle_error( FILE_OPEN_ERROR, "Configuration file cannot be found",
+                handle_error( FILE_OPEN_ERROR | SHOW_DIALOG, "Configuration file cannot be found",
                               filelist[i] );
             }
         }
@@ -278,7 +278,7 @@ int snapplot_load( int argc, char *argv[] )
         const char *filename = find_file( cfgfile[i], SNAPPLOT_CONFIG_EXT, 0, FF_TRYLOCAL, SNAPPLOT_CONFIG_SECTION );
         if( add_configuration_file( filename ) != 0 )
         {
-            handle_error( FILE_OPEN_ERROR, "Configuration file cannot be found", cfgfile[i] );
+            handle_error( FILE_OPEN_ERROR | SHOW_DIALOG, "Configuration file cannot be found", cfgfile[i] );
         }
     }
 

--- a/src/snapplot/snapplot_util.cpp
+++ b/src/snapplot/snapplot_util.cpp
@@ -96,6 +96,16 @@ static int error_handler( int sts, const char *msg1, const char *msg2 )
     else if ( WARNING_ERROR_CONDITION(sts) )
     {
         wxLogWarning( "%s %s\n", msg1 ? msg1 : blank, msg2 ? msg2 : blank );
+        // wxLogWarning's target (see ImplementErrorHandler below) only buffers
+        // messages in memory, with nothing in the UI that ever displays them -
+        // so a caller that wants this specific warning seen must ask for it
+        // explicitly via SHOW_DIALOG, rather than every warning popping up
+        // unprompted.
+        if( SHOW_DIALOG_CONDITION(sts) )
+        {
+            wxMessageBox( wxString::Format("%s %s", msg1 ? msg1 : blank, msg2 ? msg2 : blank ),
+                          "Warning", wxOK | wxICON_EXCLAMATION );
+        }
     }
     else
     {

--- a/src/snapspec/snapspec.cpp
+++ b/src/snapspec/snapspec.cpp
@@ -340,7 +340,7 @@ static int relacc_create_blt_req( stn_relacc_array *ra )
             ra->blt = NULL;
         }
 
-        BINARY_FILE *b = open_binary_file( ra->binfn, BINFILE_SIGNATURE );
+        BINARY_FILE *b = open_binary_file( ra->binfn, BINFILE_SIGNATURE ).file;
         if( !b ) { if( saved_col ) check_free( saved_col ); return 0; }
         if( find_section(b, "CHOLESKI_DECOMPOSITION") != OK )
         {
@@ -853,7 +853,7 @@ static int try_reload_cached_covariance( stn_relacc_array *ra, char *cfn )
 {
     BINARY_FILE *c;
     char cruntime[GETDATELEN];
-    c=open_binary_file(cfn,CACHE_COVARIANCE_SIG);
+    c=open_binary_file(cfn,CACHE_COVARIANCE_SIG).file;
     if( ! c ) return 0;
     if( find_section(c,CACHE_COVARIANCE_SECTION) != OK )
     {
@@ -2828,7 +2828,7 @@ int main( int argc, char *argv[] )
         return 0;
     }
 
-    b = open_binary_file( bfn, BINFILE_SIGNATURE );
+    b = open_binary_file( bfn, BINFILE_SIGNATURE ).file;
 
     if( !b ||
             reload_snap_globals( b ) != OK ||

--- a/src/test/binroundtrip/binroundtrip.cpp
+++ b/src/test/binroundtrip/binroundtrip.cpp
@@ -647,7 +647,7 @@ static ReloadedState reload_almost_everything( BINARY_FILE *in )
 
 static int run_roundtrip( const char *input_path, const char *output_path )
 {
-    BinaryFilePtr in( open_binary_file( const_cast<char *>(input_path), BINFILE_SIGNATURE ) );
+    BinaryFilePtr in( open_binary_file( const_cast<char *>(input_path), BINFILE_SIGNATURE ).file );
     if( !in ) {
         fail( std::string( "Cannot open " ) + input_path );
     }
@@ -690,7 +690,7 @@ static int run_roundtrip( const char *input_path, const char *output_path )
 // floating-point differences between compilers.
 static int run_dump( const char *input_path, const char *output_path )
 {
-    BinaryFilePtr in( open_binary_file( const_cast<char *>(input_path), BINFILE_SIGNATURE ) );
+    BinaryFilePtr in( open_binary_file( const_cast<char *>(input_path), BINFILE_SIGNATURE ).file );
     if( !in ) {
         fail( std::string( "Cannot open " ) + input_path );
     }


### PR DESCRIPTION
## Summary

`open_binary_file()` returned `NULL` for two different reasons - the file
couldn't be opened at all, or it opened fine but its signature/version
didn't match - indistinguishably. `snapplot`'s `reload_binary_data()`
silently swallowed both cases with zero reporting, even though a sibling
failure a few lines later in the same function already called
`handle_error()`.

`open_binary_file()` now returns a `BinFileOpenOutcome` (file pointer + a
`BinFileOpenResult` of `NotFound`/`InvalidVersion`/`Ok`) instead of a bare
pointer, so callers can tell the two failure modes apart:

- Only `snapplot`'s `reload_binary_data()` acts on the distinction,
  reporting `InvalidVersion` specifically.
- The other real callers (`snaplist`, `snapspec`, `binroundtrip`) just take
  `.file` as before - unchanged behaviour.
- `snapspec`'s covariance cache lookup deliberately keeps its existing
  silent-on-miss behaviour - a missing/stale cache there is normal, not an
  error.

Showing this to the user needed one more piece: `snapplot`'s own warning
handler routed `WARNING`-level messages into a `wxLogWarning` target that
nothing in the UI ever reads - so even the *existing* sibling
`handle_error` call was already silently going nowhere. Added a new
orthogonal `SHOW_DIALOG` bit (`errdef.h`) a caller can OR onto a severity
to explicitly request a `wxMessageBox` popup, rather than making every
warning pop up unprompted - `error_handler`'s signature is fixed by the
`errhandler_type` callback contract `handle_error()` invokes, so this
couldn't be a plain bool parameter.

While auditing `snapplot`'s warning-level `handle_error` calls for this,
found and fixed two more with the identical silently-invisible-warning bug
- `snapplot_load.cpp`'s "Configuration file cannot be found" messages.
These are unrelated to the binary file version issue itself (the `.spc`
config file, not the `.bin`), but share the exact same underlying
visibility bug, so fixed opportunistically in the same pass.

## Test plan

- [x] Full Linux regression suite passes (694 tests, incl. binroundtrip)
- [x] Verified interactively (native Linux build, WSLg): a deliberately
      version-mismatched `.bin` now shows a dialog with the specific reason
      and filename
- [x] Verified a missing `.bin` (the normal "no adjustment run yet" case)
      still loads silently with no dialog, unchanged from before

[GSR-986](https://toitutewhenua.atlassian.net/browse/GSR-986)

[GSR-986]: https://toitutewhenua.atlassian.net/browse/GSR-986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ