### PR TITLE
fix: sync help viewer's address bar and history with the displayed page

### DIFF
--- a/src/help/help/adjustment/index.html
+++ b/src/help/help/adjustment/index.html
@@ -43,5 +43,6 @@
 <p><a href="../programs/snap/snap_common_problems.html">Common problems in SNAP adjustments</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/adjustment/topic_fitting_control.html
+++ b/src/help/help/adjustment/topic_fitting_control.html
@@ -81,5 +81,6 @@
 <p><a href="../files/data/obs_gps_ref_frames.html">GPS reference frames</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/adjustment/topic_strategy_eccentric_stations.html
+++ b/src/help/help/adjustment/topic_strategy_eccentric_stations.html
@@ -35,5 +35,6 @@
 <p><a href="index.html">Adjustment strategies</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/adjustment/topic_strategy_gps_surveys.html
+++ b/src/help/help/adjustment/topic_strategy_gps_surveys.html
@@ -47,5 +47,6 @@
 <p><a href="topic_strategy_gross_errors.html">Using a minimum constraints adjustment to find gross errors</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/adjustment/topic_strategy_gross_errors.html
+++ b/src/help/help/adjustment/topic_strategy_gross_errors.html
@@ -79,5 +79,6 @@ From   To     Type     S.R.  Sig (%)       Line  File
 <p><a href="topic_fitting_control.html">Fitting observations into existing control</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/adjustment/topic_strategy_obs_errors.html
+++ b/src/help/help/adjustment/topic_strategy_obs_errors.html
@@ -50,5 +50,6 @@ classification    data_type   HA    error_factor  0.85</p>
 <p><a href="topic_fitting_control.html">Fitting observations into existing control</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_crdsys_def.html
+++ b/src/help/help/coordsys/crdsys_crdsys_def.html
@@ -68,5 +68,6 @@ NZGD49 "New Zealand Geodetic Datum 1949" REF_FRAME NZGD49 GEODETIC</code></pre>
 <p><a href="crdsys_file_format.html">Coordinate system file format</a></p>
 <p><a href="whatiscoordsys.html">What is a coordinate system</a></p>
 
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_ellipsoid_def.html
+++ b/src/help/help/coordsys/crdsys_ellipsoid_def.html
@@ -39,5 +39,6 @@ WGS84 "WGS84 ellipsoid" 6378137 298.257223563</code></pre>
 <p><a href="crdsys_file_format.html">Coordinate system file format</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_em.html
+++ b/src/help/help/coordsys/crdsys_em.html
@@ -34,5 +34,6 @@
 <p><a href="crdsys_crdsys_def.html">Coordinate system definition format</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_file_format.html
+++ b/src/help/help/coordsys/crdsys_file_format.html
@@ -77,5 +77,6 @@ This is defined in sections
 
 <p><a href="crdsys_file_notes.html">Coordinate system notes format</a></p>
 
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_file_notes.html
+++ b/src/help/help/coordsys/crdsys_file_notes.html
@@ -56,5 +56,6 @@ and then a final line with just the text &quot;end_note&quot;.
 
 <p><a href="crdsys_file_format.html">Coordinate system file format</a></p>
 
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_gn.html
+++ b/src/help/help/coordsys/crdsys_gn.html
@@ -36,5 +36,6 @@
 <p><a href="crdsys_crdsys_def.html">Coordinate system definition format</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_hgtref_def.html
+++ b/src/help/help/coordsys/crdsys_hgtref_def.html
@@ -74,5 +74,6 @@ BLUFHT1955_NZVD09 "Bluff 1955 (NZVD09)" NZVD09 OFFSET 0.36
 <p><a href="geoid.html">Geoid grid files</a></p>
 <p><a href="whatiscoordsys.html">What is a coordinate system</a></p>
 
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_lcc.html
+++ b/src/help/help/coordsys/crdsys_lcc.html
@@ -42,5 +42,6 @@
 <p><a href="crdsys_crdsys_def.html">Coordinate system definition format</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_nzmg.html
+++ b/src/help/help/coordsys/crdsys_nzmg.html
@@ -25,5 +25,6 @@
 <p><a href="crdsys_crdsys_def.html">Coordinate system definition format</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_ps.html
+++ b/src/help/help/coordsys/crdsys_ps.html
@@ -40,5 +40,6 @@
 <p><a href="crdsys_crdsys_def.html">Coordinate system definition format</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_refframe_def.html
+++ b/src/help/help/coordsys/crdsys_refframe_def.html
@@ -163,5 +163,6 @@ NZGD2000 &quot;New Zealand Geodetic Datum 2000&quot; ELLIPSOID GRS80 &amp;
 <p><a href="crdsys_file_format.html">Coordinate system file format</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_standard_list.html
+++ b/src/help/help/coordsys/crdsys_standard_list.html
@@ -121,5 +121,6 @@
 <p><a href="index.html">Coordinate systems in SNAP</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/crdsys_tm.html
+++ b/src/help/help/coordsys/crdsys_tm.html
@@ -43,5 +43,6 @@
 <p><a href="crdsys_crdsys_def.html">Coordinate system definition format</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/geoid.html
+++ b/src/help/help/coordsys/geoid.html
@@ -65,5 +65,6 @@ accurate to within 1m.  The model has been gridded has been calculated at a 15" 
 <p><a href="../programs/snapgeoid/index.html">Snapgeoid - add geoid heights to SNAP coordinate files</a></p>
 -->
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/gridfile_c.html
+++ b/src/help/help/coordsys/gridfile_c.html
@@ -339,6 +339,7 @@ V141,141: -0.00012834 1.534e-005
 <p><a href="../programs/concord/index.html">Concord - Coordinate conversion program</a></p>
 <p><a href="geoid.html">Geoid files</a></p>
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/coordsys/gridfile_s.html
+++ b/src/help/help/coordsys/gridfile_s.html
@@ -341,6 +341,7 @@ V141,141: -0.00012834 1.534e-005
 <p><a href="../programs/concord/index.html">Concord - coordinate conversion program</a></p>
 <p><a href="../programs/snapgeoid/index.html">Snapgeoid - add geoid heights to SNAP coordinate files</a></p>
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/coordsys/index.html
+++ b/src/help/help/coordsys/index.html
@@ -38,5 +38,6 @@ variable COORDSYSDEF to reference the alternative file. For example: </p>
 -->
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/linzdeffile.html
+++ b/src/help/help/coordsys/linzdeffile.html
@@ -625,5 +625,6 @@ program</a></p>
 <p><a href="../files/cmdcfg/cmd_deformation.html">The SNAP
 deformation command</a></p>
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/coordsys/linzdefmodel.html
+++ b/src/help/help/coordsys/linzdefmodel.html
@@ -51,6 +51,7 @@ either a grid of values (on a regular grid in the coordinate system of the defor
 <p><a href="../programs/snap/index.html">SNAP adjustment program</a></p>
 <p><a href="../files/cmdcfg/cmd_deformation.html">The SNAP deformation command</a></p>
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/coordsys/trigfile.html
+++ b/src/help/help/coordsys/trigfile.html
@@ -142,6 +142,7 @@ T 1 31 7
 <p><a href="linzdeffile.html">The LINZ deformation file format</a></p>
 <p><a href="gridfile_s.html">Gridded component file format</a></p>
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/coordsys/whatiscoordsys.html
+++ b/src/help/help/coordsys/whatiscoordsys.html
@@ -72,5 +72,6 @@ select the 20140201 version of NZGD2000 as the reference frame.
 <p><a href="crdsys_hgtref_def.html">Vertical datum definition</a></p>
 
 </div>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cfg_file.html
+++ b/src/help/help/files/cmdcfg/cfg_file.html
@@ -55,5 +55,6 @@
 <p><a href="cmd_def_res_format.html">Defining the residual listing format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_add_residual_column.html
+++ b/src/help/help/files/cmdcfg/cmd_add_residual_column.html
@@ -31,5 +31,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_additional_parameter_commands.html
+++ b/src/help/help/files/cmdcfg/cmd_additional_parameter_commands.html
@@ -84,5 +84,6 @@ refraction_coefficient  * = DEFAULT
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_additional_parameters.html
+++ b/src/help/help/files/cmdcfg/cmd_additional_parameters.html
@@ -37,5 +37,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_adjustment_mode.html
+++ b/src/help/help/files/cmdcfg/cmd_adjustment_mode.html
@@ -37,5 +37,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_alphabetic_summary.html
+++ b/src/help/help/files/cmdcfg/cmd_alphabetic_summary.html
@@ -355,6 +355,7 @@
         </tr>
     </table>
 
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/files/cmdcfg/cmd_classification.html
+++ b/src/help/help/files/cmdcfg/cmd_classification.html
@@ -62,5 +62,6 @@ processed).</p>
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_configuration.html
+++ b/src/help/help/files/cmdcfg/cmd_configuration.html
@@ -41,5 +41,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_convergence_tolerance.html
+++ b/src/help/help/files/cmdcfg/cmd_convergence_tolerance.html
@@ -29,5 +29,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_coordinate_file.html
+++ b/src/help/help/files/cmdcfg/cmd_coordinate_file.html
@@ -60,5 +60,6 @@ format can by any used by SNAP, for example decimal years, YYYYMMDD, or YYYY/MM/
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_coordinate_precision.html
+++ b/src/help/help/files/cmdcfg/cmd_coordinate_precision.html
@@ -31,5 +31,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_data_file.html
+++ b/src/help/help/files/cmdcfg/cmd_data_file.html
@@ -69,5 +69,6 @@ Translations can also be defined in the snap command file using the <a href="cmd
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_def_res_format.html
+++ b/src/help/help/files/cmdcfg/cmd_def_res_format.html
@@ -253,5 +253,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_default_refraction_coefficient.html
+++ b/src/help/help/files/cmdcfg/cmd_default_refraction_coefficient.html
@@ -37,5 +37,6 @@ which always takes the default value of 0.0.</p>
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_define_residual_format.html
+++ b/src/help/help/files/cmdcfg/cmd_define_residual_format.html
@@ -31,5 +31,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_deformation.html
+++ b/src/help/help/files/cmdcfg/cmd_deformation.html
@@ -52,5 +52,6 @@ model</a> or LINZ model. SNAP will look for this file in the same directory as t
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_error_type.html
+++ b/src/help/help/files/cmdcfg/cmd_error_type.html
@@ -51,5 +51,6 @@ either "standard_error" or "confidence_limit".  Determines the how <i>value</i> 
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_file_location_frequency.html
+++ b/src/help/help/files/cmdcfg/cmd_file_location_frequency.html
@@ -33,5 +33,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_fix.html
+++ b/src/help/help/files/cmdcfg/cmd_fix.html
@@ -79,5 +79,6 @@ fixed.
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_flag_significance.html
+++ b/src/help/help/files/cmdcfg/cmd_flag_significance.html
@@ -40,5 +40,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_float.html
+++ b/src/help/help/files/cmdcfg/cmd_float.html
@@ -49,5 +49,6 @@ float automatically horizontal all
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_free.html
+++ b/src/help/help/files/cmdcfg/cmd_free.html
@@ -39,5 +39,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_function_summary.html
+++ b/src/help/help/files/cmdcfg/cmd_function_summary.html
@@ -407,6 +407,7 @@
         </tr>
     </table>
 
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/files/cmdcfg/cmd_geoid.html
+++ b/src/help/help/files/cmdcfg/cmd_geoid.html
@@ -44,5 +44,6 @@ cannot be calculated for specific stations (when the coordinates are out of the 
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_gps_antenna_height.html
+++ b/src/help/help/files/cmdcfg/cmd_gps_antenna_height.html
@@ -56,6 +56,7 @@
         <p><a href="cmd_stn_list.html">Station lists</a></p>
 
     </div>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/files/cmdcfg/cmd_gps_vertical.html
+++ b/src/help/help/files/cmdcfg/cmd_gps_vertical.html
@@ -43,5 +43,6 @@ a separate rotation rotation matrix can be calculated for each point or baseline
 <p><a href="cmd_topocentre.html">The topocentre command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_horizontal_float_error.html
+++ b/src/help/help/files/cmdcfg/cmd_horizontal_float_error.html
@@ -31,5 +31,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_ignore_missing_stations.html
+++ b/src/help/help/files/cmdcfg/cmd_ignore_missing_stations.html
@@ -51,5 +51,6 @@ continue to run the adjustment.
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_ignore_observations.html
+++ b/src/help/help/files/cmdcfg/cmd_ignore_observations.html
@@ -51,5 +51,6 @@ have residuals calculated, whereas ignored observations are not included in the 
 <p><a href="cmd_stn_list.html">Station lists</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_include.html
+++ b/src/help/help/files/cmdcfg/cmd_include.html
@@ -35,5 +35,6 @@ and it includes a command &quot;<tt>data_file data/traverse.dat</tt>&quot;, then
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_list.html
+++ b/src/help/help/files/cmdcfg/cmd_list.html
@@ -148,5 +148,6 @@ use E, N, U residuals.</p>
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_magic_number.html
+++ b/src/help/help/files/cmdcfg/cmd_magic_number.html
@@ -14,5 +14,6 @@
 
 <p>The magic number command is used to modify internal program values.  Each id corresponds to a parameter.  Currently two ids, 1 and 2, are supported.  They are used to modify the numbers SNAP uses to detect a singularity in the normal equations.  id=1 is a proportional measure and id=2 is an absolute measure.  The command multiplies these measures by value.  That is, if value is greater than one then singularities are more likely to be detected.</p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_max_adjustment.html
+++ b/src/help/help/files/cmdcfg/cmd_max_adjustment.html
@@ -29,5 +29,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_max_iterations.html
+++ b/src/help/help/files/cmdcfg/cmd_max_iterations.html
@@ -29,5 +29,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_mde_power.html
+++ b/src/help/help/files/cmdcfg/cmd_mde_power.html
@@ -19,5 +19,6 @@
 
 <p class="Commanddefinition">power</p><p class="Commanddescription">Defines the power for which the marginal detectable error is calculated as a percentage.</p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_min_iterations.html
+++ b/src/help/help/files/cmdcfg/cmd_min_iterations.html
@@ -29,5 +29,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_mode.html
+++ b/src/help/help/files/cmdcfg/cmd_mode.html
@@ -38,5 +38,6 @@ mode  horizontal network_analysis
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_number_of_worst_residuals.html
+++ b/src/help/help/files/cmdcfg/cmd_number_of_worst_residuals.html
@@ -31,5 +31,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_output.html
+++ b/src/help/help/files/cmdcfg/cmd_output.html
@@ -78,5 +78,6 @@ the covariance matrix of the solution.
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_output_coordinate_file.html
+++ b/src/help/help/files/cmdcfg/cmd_output_coordinate_file.html
@@ -45,5 +45,6 @@ new coordinate file.
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_output_csv.html
+++ b/src/help/help/files/cmdcfg/cmd_output_csv.html
@@ -66,5 +66,6 @@ The syntax of the output_csv command is very similar to that for the list comman
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_output_precision.html
+++ b/src/help/help/files/cmdcfg/cmd_output_precision.html
@@ -39,5 +39,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_plot.html
+++ b/src/help/help/files/cmdcfg/cmd_plot.html
@@ -22,5 +22,6 @@
 <p><a href="../../programs/snapplot/sp_commandfile.html">snapplot commands in the command file</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_proj_bearing_use_datum.html
+++ b/src/help/help/files/cmdcfg/cmd_proj_bearing_use_datum.html
@@ -46,5 +46,6 @@ network coordinate system datum are ignored.
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_recode.html
+++ b/src/help/help/files/cmdcfg/cmd_recode.html
@@ -121,5 +121,6 @@ a suffix _A to allow a different value.
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_redundancy_flag_level.html
+++ b/src/help/help/files/cmdcfg/cmd_redundancy_flag_level.html
@@ -31,5 +31,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_reference_frame.html
+++ b/src/help/help/files/cmdcfg/cmd_reference_frame.html
@@ -185,5 +185,6 @@ reference_frame ITRF2008 IERS_ETSR 2000.0 -4.8 -2.09 17.67 -1.40901 0.16508 -0.2
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_reject.html
+++ b/src/help/help/files/cmdcfg/cmd_reject.html
@@ -41,5 +41,6 @@ accept  [all] <i>station_list</i>
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_reject_observations.html
+++ b/src/help/help/files/cmdcfg/cmd_reject_observations.html
@@ -102,5 +102,6 @@ be selected.
 <p><a href="cmd_stn_list.html">Station lists</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_reorder_stations.html
+++ b/src/help/help/files/cmdcfg/cmd_reorder_stations.html
@@ -33,5 +33,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_reweight_observations.html
+++ b/src/help/help/files/cmdcfg/cmd_reweight_observations.html
@@ -92,5 +92,6 @@ have residuals calculated, whereas ignored observations are not included in the 
 <p><a href="cmd_stn_list.html">Station lists</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_set_observation_option.html
+++ b/src/help/help/files/cmdcfg/cmd_set_observation_option.html
@@ -68,5 +68,6 @@ set_observation_option no_calculate_gx_translation</p>
 <p><a href="cmd_reject_observations.html">The reject_observations command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_sort_observations.html
+++ b/src/help/help/files/cmdcfg/cmd_sort_observations.html
@@ -39,5 +39,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_spec_test_options.html
+++ b/src/help/help/files/cmdcfg/cmd_spec_test_options.html
@@ -43,5 +43,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_specification.html
+++ b/src/help/help/files/cmdcfg/cmd_specification.html
@@ -69,5 +69,6 @@ specification tests are by default apriori confidence limits.  This may be chang
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_station_code_width.html
+++ b/src/help/help/files/cmdcfg/cmd_station_code_width.html
@@ -31,5 +31,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_station_offset_file.html
+++ b/src/help/help/files/cmdcfg/cmd_station_offset_file.html
@@ -36,5 +36,6 @@ the deformation model.
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_station_options.html
+++ b/src/help/help/files/cmdcfg/cmd_station_options.html
@@ -61,5 +61,6 @@ may be different to its actual position after the event because of the unknown e
 <p><a href="../crd/index.html">The station coordinate file</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_stn_list.html
+++ b/src/help/help/files/cmdcfg/cmd_stn_list.html
@@ -165,5 +165,6 @@ This algorithm handles polygons definitions which include holes.
 <p><a href="../crd/index.html">The station coordinate file</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_summarize_errors_by.html
+++ b/src/help/help/files/cmdcfg/cmd_summarize_errors_by.html
@@ -45,5 +45,6 @@ This can be suppressed by specifying the classification as &quot;data_type:no_en
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_syntax.html
+++ b/src/help/help/files/cmdcfg/cmd_syntax.html
@@ -41,5 +41,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_test_specification.html
+++ b/src/help/help/files/cmdcfg/cmd_test_specification.html
@@ -41,5 +41,6 @@ Unlike the test_specification command, snapspec is not used to test a specific s
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_title.html
+++ b/src/help/help/files/cmdcfg/cmd_title.html
@@ -30,5 +30,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_topocentre.html
+++ b/src/help/help/files/cmdcfg/cmd_topocentre.html
@@ -32,5 +32,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_use_distance_ratios.html
+++ b/src/help/help/files/cmdcfg/cmd_use_distance_ratios.html
@@ -29,5 +29,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_use_zero_inverse.html
+++ b/src/help/help/files/cmdcfg/cmd_use_zero_inverse.html
@@ -32,5 +32,6 @@ You can achieve the same result with the snap -z option.
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/cmd_vertical_float_error.html
+++ b/src/help/help/files/cmdcfg/cmd_vertical_float_error.html
@@ -31,5 +31,6 @@
 <p><a href="cmd_function_summary.html">Summary of commands by function</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/cmdcfg/csv_format_definition.html
+++ b/src/help/help/files/cmdcfg/csv_format_definition.html
@@ -594,6 +594,7 @@
 		<p><a href="../data/index.html">Observation files</a></p>
 
 	</div>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/files/cmdcfg/index.html
+++ b/src/help/help/files/cmdcfg/index.html
@@ -63,5 +63,6 @@ fix vertical  BM328
 
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/crd/csv_stn_files.html
+++ b/src/help/help/files/crd/csv_stn_files.html
@@ -61,5 +61,6 @@ WHNG,COMM,OTHR,Y,AK,2k0,-35.80377146,174.31456670,172.815,Whangarei GPS,,
 <p><a href="stn_code.html">Station codes</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/crd/index.html
+++ b/src/help/help/files/crd/index.html
@@ -113,6 +113,7 @@
         <p><a href="../../coordsys/crdsys_standard_list.html">Standard coordinate systems provided with SNAP</a></p>
 
     </div>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/files/crd/stn_code.html
+++ b/src/help/help/files/crd/stn_code.html
@@ -21,5 +21,6 @@
 <p><a href="index.html">Station coordinate file</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/crd/stn_crd_file_example.html
+++ b/src/help/help/files/crd/stn_crd_file_example.html
@@ -85,5 +85,6 @@ A28B    397845.805   801485.001      0.000  13.160 5 PIPE OLD KARORI
 
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/crd/stn_file_format.html
+++ b/src/help/help/files/crd/stn_file_format.html
@@ -129,5 +129,6 @@ and longitude are entered as decimal degrees, for example</p>
 <p><a href="../../coordsys/crdsys_standard_list.html">Standard coordinate systems provided with SNAP</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/crd/stn_offset_file_format.html
+++ b/src/help/help/files/crd/stn_offset_file_format.html
@@ -90,5 +90,6 @@ Dates are entered using the format &quot;YYYY-MM-DD&quot; or &quot;YYYY-MM-DD:hh
 <p><a href="../cmdcfg/cmd_station_offset_file.html">The station_offset_file command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/crd/stn_recode_file.html
+++ b/src/help/help/files/crd/stn_recode_file.html
@@ -73,5 +73,6 @@ create a new station based on the original one.
     <p><a href="../cmdcfg/cmd_recode.html">The recode command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/csv_obs_files.html
+++ b/src/help/help/files/data/csv_obs_files.html
@@ -77,5 +77,6 @@ EHJJ,DLL1,2010.279,20.12,437.321,70.833,-492.196,VII,Mangawhai Heads,STAT1,
 <p><a href="obs_data_types.html">Summary of data types</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/index.html
+++ b/src/help/help/files/data/index.html
@@ -50,5 +50,6 @@ metres, and all angles and angle errors are expressed in degrees.</p>
 
 <p><a href="obs_example_file.html">Example data file</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_azimuth_data.html
+++ b/src/help/help/files/data/obs_azimuth_data.html
@@ -45,5 +45,6 @@
 
 <p><a href="obs_ddc_angles.html">The #hp_angles, #deg_angles, and #dms_angles commands</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_bearing_error.html
+++ b/src/help/help/files/data/obs_bearing_error.html
@@ -31,5 +31,6 @@
 <p><a href="../cmdcfg/cmd_additional_parameter_commands.html">The bearing_orientation_error  command (command file)</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_classifications.html
+++ b/src/help/help/files/data/obs_classifications.html
@@ -49,5 +49,6 @@ In <a href="obs_file_format.html">SNAP format files</a> these are defined using 
 <p><a href="obs_example_classification.html">Example of data classification</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_data_file_errors.html
+++ b/src/help/help/files/data/obs_data_file_errors.html
@@ -82,5 +82,6 @@
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_data_types.html
+++ b/src/help/help/files/data/obs_data_types.html
@@ -186,5 +186,6 @@ command</b></td>
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_alphabetically.html
+++ b/src/help/help/files/data/obs_ddc_alphabetically.html
@@ -152,5 +152,6 @@
 </tr>
 </table>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_angles.html
+++ b/src/help/help/files/data/obs_ddc_angles.html
@@ -42,5 +42,6 @@ This option does not affect angle observation errors specified with error comman
 <p><a href="obs_data_types.html">Summary of data types</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_bearing_orientation_error.html
+++ b/src/help/help/files/data/obs_ddc_bearing_orientation_error.html
@@ -31,5 +31,6 @@
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_by_func.html
+++ b/src/help/help/files/data/obs_ddc_by_func.html
@@ -166,5 +166,6 @@
 </tr>
 </table>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_classification.html
+++ b/src/help/help/files/data/obs_ddc_classification.html
@@ -37,5 +37,6 @@
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_classify.html
+++ b/src/help/help/files/data/obs_ddc_classify.html
@@ -45,5 +45,6 @@
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_data.html
+++ b/src/help/help/files/data/obs_ddc_data.html
@@ -82,5 +82,6 @@ STN4    89 08 37.5     987.65  0.02</p>
 <p><a href="obs_classifications.html">Observation classifications</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_date.html
+++ b/src/help/help/files/data/obs_ddc_date.html
@@ -66,5 +66,6 @@ and for <a href="../cmdcfg/cmd_recode.html">recoding stations</a> used in the ob
 <p><a href="../cmdcfg/cmd_ignore_observations.html">The ignore_observation command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_distance_scale_error.html
+++ b/src/help/help/files/data/obs_ddc_distance_scale_error.html
@@ -31,5 +31,6 @@
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_ds_error.html
+++ b/src/help/help/files/data/obs_ddc_ds_error.html
@@ -33,5 +33,6 @@
 <p><a href="obs_ddc_alphabetically.html">Data definition commands listed alphabetically</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_gps_enu_error.html
+++ b/src/help/help/files/data/obs_ddc_gps_enu_error.html
@@ -33,5 +33,6 @@
 <p><a href="obs_ddc_alphabetically.html">Data definition commands listed alphabetically</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_gps_error_type.html
+++ b/src/help/help/files/data/obs_ddc_gps_error_type.html
@@ -27,5 +27,6 @@
 <p><a href="obs_data_types.html">Summary of data types</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_gx_enu_error.html
+++ b/src/help/help/files/data/obs_ddc_gx_enu_error.html
@@ -38,5 +38,6 @@ feature may not be available, or may change incompatibly,  in future versions of
 <p><a href="obs_ddc_alphabetically.html">Data definition commands listed alphabetically</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_hazdaz_error.html
+++ b/src/help/help/files/data/obs_ddc_hazdaz_error.html
@@ -47,5 +47,6 @@ coordinates to recalculate the errors.</p>
 <p><a href="obs_ddc_alphabetically.html">Data definition commands listed alphabetically</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_ltln_error.html
+++ b/src/help/help/files/data/obs_ddc_ltln_error.html
@@ -32,5 +32,6 @@
 <p><a href="obs_ddc_alphabetically.html">Data definition commands listed alphabetically</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_lv_error.html
+++ b/src/help/help/files/data/obs_ddc_lv_error.html
@@ -31,5 +31,6 @@
 <p><a href="obs_ddc_alphabetically.html">Data definition commands listed alphabetically</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_note.html
+++ b/src/help/help/files/data/obs_ddc_note.html
@@ -27,5 +27,6 @@
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_oheh_error.html
+++ b/src/help/help/files/data/obs_ddc_oheh_error.html
@@ -32,5 +32,6 @@
 <p><a href="obs_ddc_alphabetically.html">Data definition commands listed alphabetically</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_projection.html
+++ b/src/help/help/files/data/obs_ddc_projection.html
@@ -33,5 +33,6 @@
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_ref_coeff.html
+++ b/src/help/help/files/data/obs_ddc_ref_coeff.html
@@ -32,5 +32,6 @@ if the survey equipment has already applied a refraction correction.<p>
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_reference_frame.html
+++ b/src/help/help/files/data/obs_ddc_reference_frame.html
@@ -38,5 +38,6 @@ By default GPS observations are assigned to reference frame &quot;GPS&quot;.
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ddc_time.html
+++ b/src/help/help/files/data/obs_ddc_time.html
@@ -29,5 +29,6 @@
 <p><a href="obs_ddc_data.html">The #data command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_dist_scale_errors.html
+++ b/src/help/help/files/data/obs_dist_scale_errors.html
@@ -33,5 +33,6 @@
 <p><a href="../cmdcfg/cmd_additional_parameter_commands.html">The distance_scale_error command (command file)</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_distance_data.html
+++ b/src/help/help/files/data/obs_distance_data.html
@@ -59,5 +59,6 @@
 
 <p><a href="obs_ddc_distance_scale_error.html">The #distance_scale_error command</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_distance_ratios.html
+++ b/src/help/help/files/data/obs_distance_ratios.html
@@ -45,5 +45,6 @@
 
 <p><a href="../cmdcfg/cmd_use_distance_ratios.html">The use_distance_ratios command</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_example_classification.html
+++ b/src/help/help/files/data/obs_example_classification.html
@@ -52,5 +52,6 @@
 <p><a href="obs_ddc_data.html">The #data command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_example_file.html
+++ b/src/help/help/files/data/obs_example_file.html
@@ -92,5 +92,6 @@
 <p><a href="obs_file_format.html">Observation file format</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_file_format.html
+++ b/src/help/help/files/data/obs_file_format.html
@@ -118,5 +118,6 @@ S02  1.21  S01  0.95   1051.815
 <p><a href="obs_ddc_alphabetically.html">Data definition commands listed alphabetically</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_format_covar.html
+++ b/src/help/help/files/data/obs_format_covar.html
@@ -60,5 +60,6 @@ covariance_matrix_elements ....
 <p><a href="obs_ddc_data.html">The #data command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_format_grouped.html
+++ b/src/help/help/files/data/obs_format_grouped.html
@@ -57,5 +57,6 @@ stn_definition  observation observation
 <p><a href="obs_ddc_data.html">The #data command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_format_line.html
+++ b/src/help/help/files/data/obs_format_line.html
@@ -35,5 +35,6 @@ inst_stn_definition   trgt_stn_definition   observation   observation
 <p><a href="obs_ddc_data.html">The #data command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_format_point.html
+++ b/src/help/help/files/data/obs_format_point.html
@@ -37,5 +37,6 @@ inst_stn_definition   observation   observation
 <p><a href="obs_ddc_data.html">The #data command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_gps_data.html
+++ b/src/help/help/files/data/obs_gps_data.html
@@ -63,5 +63,6 @@
 
 <p><a href="../cmdcfg/cmd_gps_vertical.html">The gps_vertical command</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_gps_err_format.html
+++ b/src/help/help/files/data/obs_gps_err_format.html
@@ -96,5 +96,6 @@ c(y2,x1) ....</p>
 <p><a href="../cmdcfg/cmd_topocentre.html">The topocentre command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_gps_ref_frames.html
+++ b/src/help/help/files/data/obs_gps_ref_frames.html
@@ -70,6 +70,7 @@
 
     <p><a href="../cmdcfg/cmd_topocentre.html">The topocentre command</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/files/data/obs_gx_data.html
+++ b/src/help/help/files/data/obs_gx_data.html
@@ -64,5 +64,6 @@ This is specified by the <a href="../cmdcfg/cmd_reference_frame.html">reference_
 
 <p><a href="../cmdcfg/cmd_gps_vertical.html">The gps_vertical command</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_gx_err_format.html
+++ b/src/help/help/files/data/obs_gx_err_format.html
@@ -103,5 +103,6 @@ c(y2,x1) ....</p>
 <p><a href="../cmdcfg/cmd_topocentre.html">The topocentre command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_height_data.html
+++ b/src/help/help/files/data/obs_height_data.html
@@ -29,5 +29,6 @@
 
 <p><a href="obs_ddc_oheh_error.html">The #oh_error and #eh_error commands</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_height_differences.html
+++ b/src/help/help/files/data/obs_height_differences.html
@@ -29,5 +29,6 @@
 
 <p><a href="obs_ddc_lv_error.html">The #lv_error command</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_horizontal_angles.html
+++ b/src/help/help/files/data/obs_horizontal_angles.html
@@ -47,5 +47,6 @@
 
 <p><a href="obs_ddc_angles.html">The #hp_angles, #deg_angles, and #dms_angles commands</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_latlon_data.html
+++ b/src/help/help/files/data/obs_latlon_data.html
@@ -33,5 +33,6 @@
 
 <p><a href="obs_ddc_ltln_error.html">The #lt_error and #ln_error commands</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_projection_bearings.html
+++ b/src/help/help/files/data/obs_projection_bearings.html
@@ -57,5 +57,6 @@ command in the SNAP command file.
 
 <p><a href="../cmdcfg/cmd_proj_bearing_use_datum.html">The proj_bearing_use_datum command</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_ref_coeff.html
+++ b/src/help/help/files/data/obs_ref_coeff.html
@@ -43,5 +43,6 @@ survey equipment has already applied a refraction coefficient correction.
 <p><a href="../cmdcfg/cmd_default_refraction_coefficient.html">The default_refraction_coefficient command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_refframe_scale_error.html
+++ b/src/help/help/files/data/obs_refframe_scale_error.html
@@ -33,5 +33,6 @@
 <p><a href="../cmdcfg/cmd_additional_parameter_commands.html">The reference_frame_scale_error  command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_rejecting_data.html
+++ b/src/help/help/files/data/obs_rejecting_data.html
@@ -39,5 +39,6 @@ STN2      0 00 00.0<br>
 #note   (See field book 101/3 page 15)<br>
 STN3  *30 00 23.4</p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_user_errors.html
+++ b/src/help/help/files/data/obs_user_errors.html
@@ -23,5 +23,6 @@
 <p><a href="../cmdcfg/cmd_additional_parameters.html">Additional adjustment parameters</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/obs_zenith_distances.html
+++ b/src/help/help/files/data/obs_zenith_distances.html
@@ -40,5 +40,6 @@
 
 <p><a href="obs_ddc_angles.html">The #hp_angles, #deg_angles, and #dms_angles commands</a></p>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/data/sinex_obs_files.html
+++ b/src/help/help/files/data/sinex_obs_files.html
@@ -47,5 +47,6 @@ Both upper and lower triangular formats are supported. The SINEX file should con
 <p><a href="obs_data_types.html">Summary of data types</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/files/index.html
+++ b/src/help/help/files/index.html
@@ -230,5 +230,6 @@ names must be enclosed in quote marks.  For example:
 <p>Note that this support is incomplete. The snap_manager program does not support spaces in file names.  
 Also file names with spaces cannot be referenced in data file classifications (@data_file) used in commands for modifying observations, for example the reweight_observations command.
 </p>
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/general/changelog.html
+++ b/src/help/help/general/changelog.html
@@ -953,6 +953,7 @@ program without requiring an installation package</p>
     <p>Bug fix: Fixed a bug whereby snapspec was not able to find
         its default configuration file.</p>
 
+<script src="../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/js/helpapp.js
+++ b/src/help/help/js/helpapp.js
@@ -23,9 +23,15 @@ function toggleContentsLevel( item )
     }
 }
 
-function setPage( url )
+function helpRootRelativeUrl( absoluteUrl )
 {
-    $('#help-page').attr("src",url); 
+    let base=window.location.href.split(/[?#]/)[0];
+    base=base.substring(0,base.lastIndexOf('/')+1);
+    return absoluteUrl.startsWith(base) ? absoluteUrl.substring(base.length) : absoluteUrl;
+}
+
+function highlightPage( url )
+{
     $(".contents-item").removeClass("selected");
     $(".contents-item a").each(function(){
         if( $(this).attr("href") == url )
@@ -34,6 +40,11 @@ function setPage( url )
             $(this).parents(".contents-level").each(function(){openContentsLevel($(this));});
         }
     });
+}
+
+function setPage( url )
+{
+    $('#help-page').attr("src",url);
 }
 
 function installContents()
@@ -364,7 +375,22 @@ function setup()
     installContents();
     let url= window.location.search ? window.location.search.substring(1) : $('.contents-item a').first().attr("href");
     setPage(url);
-    $(window).on("keydown",function(e){ 
+    $(window).on("message",function(e){
+        // The browser already creates its own joint-history entry for every
+        // iframe navigation (sidebar/search click, in-page content link, or a
+        // back/forward traversal restoring one) - whether we drove it or the
+        // user did. So this only ever labels the entry the browser just made;
+        // it must never pushState, or it would add a redundant second entry on
+        // top of that implicit one (which is what used to make Back land on a
+        // stale entry whose address had changed but whose content hadn't).
+        let msg=e.originalEvent;
+        if( ! msg.data || msg.data.type !== "snap-help-page" ) return;
+        if( msg.source !== document.getElementById('help-page').contentWindow ) return;
+        let pageurl=helpRootRelativeUrl(msg.data.url);
+        highlightPage(pageurl);
+        history.replaceState({page:pageurl},"","?"+pageurl);
+    });
+    $(window).on("keydown",function(e){
         if( e.altKey && e.key == 'c' )
         {
             $('#show-contents-button').click();

--- a/src/help/help/js/helppage.js
+++ b/src/help/help/js/helppage.js
@@ -1,0 +1,7 @@
+window.addEventListener( "pageshow", function()
+{
+    if( window.parent !== window )
+    {
+        window.parent.postMessage( { type: "snap-help-page", url: location.href }, "*" );
+    }
+});

--- a/src/help/help/programs/concord/error.html
+++ b/src/help/help/programs/concord/error.html
@@ -52,6 +52,7 @@ Note that the NZGeoid09 model is only defined in the vicinity of
 New Zealand.</p>
 
 
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/concord/example.html
+++ b/src/help/help/programs/concord/example.html
@@ -92,6 +92,7 @@ Enter name, easting, northing:
 
 C:\&gt;
 </pre>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/concord/index.html
+++ b/src/help/help/programs/concord/index.html
@@ -361,6 +361,7 @@ coordinates.</p>
 
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/dat2site/example.html
+++ b/src/help/help/programs/dat2site/example.html
@@ -154,6 +154,7 @@ id (blank to quit):</p>
 
 
 
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/dat2site/index.html
+++ b/src/help/help/programs/dat2site/index.html
@@ -207,6 +207,7 @@ have not been located.</p>
 
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/index.html
+++ b/src/help/help/programs/index.html
@@ -145,5 +145,6 @@ Converts coordinates between different coordinate systems
 </tr>
 </table>
 
+<script src="../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/site2gps/index.html
+++ b/src/help/help/programs/site2gps/index.html
@@ -109,6 +109,7 @@ excluded by the -c parameter
 <p><a href="../../files/cmdcfg/index.html">Command files</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/snap/index.html
+++ b/src/help/help/programs/snap/index.html
@@ -97,5 +97,6 @@ for gross residuals, but means that statistics are not correct
 <p><a href="../../files/cmdcfg/cfg_file.html">Configuration file overview</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/snap_common_problems.html
+++ b/src/help/help/programs/snap/snap_common_problems.html
@@ -25,5 +25,6 @@
 	<li><a href="snap_prob_memory.html">There is not enough memory for the program</a></li>
 </ul>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/snap_prob_converge.html
+++ b/src/help/help/programs/snap/snap_prob_converge.html
@@ -27,5 +27,6 @@
 <p><a href="snap_common_problems.html">Common problems in SNAP adjustments</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/snap_prob_format.html
+++ b/src/help/help/programs/snap/snap_prob_format.html
@@ -21,5 +21,6 @@
 <p><a href="snap_common_problems.html">Common problems in SNAP adjustments</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/snap_prob_memory.html
+++ b/src/help/help/programs/snap/snap_prob_memory.html
@@ -21,5 +21,6 @@
 <p><a href="snap_common_problems.html">Common problems in SNAP adjustments</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/snap_prob_singularity.html
+++ b/src/help/help/programs/snap/snap_prob_singularity.html
@@ -21,5 +21,6 @@
 <p><a href="snap_common_problems.html">Common problems in SNAP adjustments</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/snap_proc_accspec.html
+++ b/src/help/help/programs/snap/snap_proc_accspec.html
@@ -145,5 +145,6 @@ Horizontal tolerance:
 <p><a href="../../files/cmdcfg/cmd_spec_test_options.html">The spec_test_options command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/snap_proc_basic.html
+++ b/src/help/help/programs/snap/snap_proc_basic.html
@@ -23,5 +23,6 @@
 	<li><a href="topic_adjustment_outputs.html">Review the results in the listing file</a>.  If any problems are identified, correct the input files and run again.</li>
 </ul>
 
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/snap_proc_preanalysis.html
+++ b/src/help/help/programs/snap/snap_proc_preanalysis.html
@@ -31,5 +31,6 @@
 <p><a href="../site2gps/index.html">The site2gps program</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/snap_proc_vertical.html
+++ b/src/help/help/programs/snap/snap_proc_vertical.html
@@ -29,5 +29,6 @@
 <p><a href="../../files/data/obs_ref_coeff.html">Refraction coefficients</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/topic_adjustment_outputs.html
+++ b/src/help/help/programs/snap/topic_adjustment_outputs.html
@@ -45,5 +45,6 @@
 <p><a href="../../files/cmdcfg/cmd_output_csv.html">The output_csv command</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap/topic_input_files.html
+++ b/src/help/help/programs/snap/topic_input_files.html
@@ -41,5 +41,6 @@
 <p><a href="../../adjustment/index.html">Adjustment strategies</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap_manager/index.html
+++ b/src/help/help/programs/snap_manager/index.html
@@ -38,6 +38,7 @@ more information see <a href="script.html">snap_manager scripting</a>.
 <p><a href="../index.html">Snap programs</a></p>
 </div>
 
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/snap_manager/resyntax.html
+++ b/src/help/help/programs/snap_manager/resyntax.html
@@ -680,5 +680,6 @@ completely literally. We can ensure this by escaping the \ and
 &amp; characters in the string ..</p>
 <p class="Commandexample">$replacestring =
 Replace($string,'(\\|\&amp;)','\\\0')</p>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap_manager/script.html
+++ b/src/help/help/programs/snap_manager/script.html
@@ -251,5 +251,6 @@ $vmin,$vmax=minmax(5,3)
 
 </pre>
 <hr>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snap_manager/script_functions.html
+++ b/src/help/help/programs/snap_manager/script_functions.html
@@ -563,6 +563,7 @@ substitutions being made:</p>
 window.</p>
 <p class="Commanddefinition"><a name="func_ClearLog"></a>ClearLog()</p> <p class="Commanddescription">Clears all messages from the log
 window.</p>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>
 

--- a/src/help/help/programs/snap_manager/script_ui.html
+++ b/src/help/help/programs/snap_manager/script_ui.html
@@ -212,5 +212,6 @@ control</p>
 <p class="Commanddescription">Starts a new row of columns of controls</p>
 <hr>
 <a name="sysvar" id="sysvar"></a>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapconv/index.html
+++ b/src/help/help/programs/snapconv/index.html
@@ -143,6 +143,7 @@
                 <p><a href="../snapgeoid/index.html">The snapgeoid program</a></p>
                 <p><a href="../../coordsys/index.html">Coordinate systems in SNAP</a></p>
         </div>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/snapgeoid/index.html
+++ b/src/help/help/programs/snapgeoid/index.html
@@ -282,6 +282,7 @@
 
 
     </div>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/snaplist/index.html
+++ b/src/help/help/programs/snaplist/index.html
@@ -523,6 +523,7 @@ the underscore character</p>
 </table>
 
 
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/snapmerge/index.html
+++ b/src/help/help/programs/snapmerge/index.html
@@ -120,6 +120,7 @@ This is a simple text file containing a list of station codes.
 <h3>See also:</h3>
 <p><a href="../../files/crd/index.html">Station coordinate files</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 
 </html>

--- a/src/help/help/programs/snapplot/background.html
+++ b/src/help/help/programs/snapplot/background.html
@@ -69,5 +69,6 @@ start of the file, with pen codes 0 and 1:
 <h3>See also:</h3>
 <p><a href="../../coordsys/crdsys_standard_list.html">Projection codes</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/configcmd.html
+++ b/src/help/help/programs/snapplot/configcmd.html
@@ -237,5 +237,6 @@ This command specifies the settings for an item on the key.  "key item name" is 
 <p><a href="configuration.html">Snapplot configuration</a></p>
 <p><a href="sp_commandfile.html">Snapplot commands in the command file</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/configuration.html
+++ b/src/help/help/programs/snapplot/configuration.html
@@ -125,5 +125,6 @@ key "Map background" WHITE
 <p><a href="dlg_obs_display_options.html">The observation display options dialog</a></p>
 <p><a href="dlg_error_options.html">The error options dialog</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/copy.html
+++ b/src/help/help/programs/snapplot/copy.html
@@ -32,5 +32,6 @@
 <p><a href="index.html">snapplot</a></p>
 <p><a href="export.html">Exporting and printing the map</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/details_window.html
+++ b/src/help/help/programs/snapplot/details_window.html
@@ -42,5 +42,6 @@ and observations can be selected from the <a href="obs_window.html">observations
 <p><a href="dlg_error_options.html">The error options dialog</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/dlg_error_options.html
+++ b/src/help/help/programs/snapplot/dlg_error_options.html
@@ -82,5 +82,6 @@ Note these settings also apply to drawing the vertical adjustment.</td>
 <h3>See also:</h3>
 <p><a href="index.html">snapplot</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/dlg_find_station.html
+++ b/src/help/help/programs/snapplot/dlg_find_station.html
@@ -30,5 +30,6 @@ be zoomed to bring the station to the centre of the map.
 <h3>See also:</h3>
 <p><a href="index.html">snapplot</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/dlg_hideshow_stations.html
+++ b/src/help/help/programs/snapplot/dlg_hideshow_stations.html
@@ -116,5 +116,6 @@ stations will be displayed.  Otherwise they will not.</td>
 <h3>See also:</h3>
 <p><a href="index.html">snapplot</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/dlg_highlight_observations.html
+++ b/src/help/help/programs/snapplot/dlg_highlight_observations.html
@@ -93,5 +93,6 @@ standardised residuals or redundancy factor.</td>
 <p><a href="dlg_highlight_stations.html">The highlight stations dialog</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/dlg_highlight_stations.html
+++ b/src/help/help/programs/snapplot/dlg_highlight_stations.html
@@ -115,5 +115,6 @@ Other criteria for highlighting observations may be selected in the
 <p><a href="map_window.html">The map</a></p>
 <p><a href="dlg_highlight_observations.html">The highlight observations dialog</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/dlg_obs_display_options.html
+++ b/src/help/help/programs/snapplot/dlg_obs_display_options.html
@@ -73,5 +73,6 @@ Stations are hidden with the <a href="dlg_hideshow_stations.html">hide stations<
 <p><a href="map_window.html">The map window</a></p>
 <p><a href="dlg_hideshow_stations.html">The hide stations dialog</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/dlg_obs_listing_options.html
+++ b/src/help/help/programs/snapplot/dlg_obs_listing_options.html
@@ -49,5 +49,6 @@ rejected observations (those explicitly rejected from the adjustment).</td>
 <p><a href="index.html">snapplot</a></p>
 <p><a href="obs_window.html">The observations list</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/dlg_redundancy_pens.html
+++ b/src/help/help/programs/snapplot/dlg_redundancy_pens.html
@@ -46,5 +46,6 @@ back to 5 classes instead.
 <h3>See also:</h3>
 <p><a href="index.html">snapplot</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/dlg_stdres_pens.html
+++ b/src/help/help/programs/snapplot/dlg_stdres_pens.html
@@ -63,5 +63,6 @@ back to 5 classes instead.
 <h3>See also:</h3>
 <p><a href="index.html">snapplot</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/export.html
+++ b/src/help/help/programs/snapplot/export.html
@@ -30,5 +30,6 @@
 <p><a href="map_window.html">The map window</a></p>
 <p><a href="copy.html">Copying to the clipboard</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/index.html
+++ b/src/help/help/programs/snapplot/index.html
@@ -43,5 +43,6 @@ and a <a href="obs_window.html">list of observations</a>.
 <p><a href="../snap/index.html">snap</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/key_window.html
+++ b/src/help/help/programs/snapplot/key_window.html
@@ -116,5 +116,6 @@ stations are selected with the <a href="dlg_highlight_stations.html">highlight s
 <p><a href="index.html">snapplot</a></p>
 <p><a href="dlg_obs_display_options.html">The observation display options dialog</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/map_window.html
+++ b/src/help/help/programs/snapplot/map_window.html
@@ -161,5 +161,6 @@ Changing the scaling of error ellipses and vertical error bars using the
 <p><a href="key_window.html">Using the map key</a></p>
 <p><a href="background.html">Displaying background graphical items</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/obs_window.html
+++ b/src/help/help/programs/snapplot/obs_window.html
@@ -40,5 +40,6 @@ If the row is double-clicked details of the observation are shown in the <a href
 <h3>See also:</h3>
 <p><a href="index.html">snapplot</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/sp_commandfile.html
+++ b/src/help/help/programs/snapplot/sp_commandfile.html
@@ -44,5 +44,6 @@ coordinate system of the adjustment.</p>
 <p><a href="../../coordsys/crdsys_standard_list.html">Coordinate system codes</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/starting.html
+++ b/src/help/help/programs/snapplot/starting.html
@@ -70,5 +70,6 @@ stations and observations without statistical information.
 <p><a href="configuration.html">snapplot configuration</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapplot/station_window.html
+++ b/src/help/help/programs/snapplot/station_window.html
@@ -28,5 +28,6 @@ Double clicking will display detailed information about it in the <a href="detai
 <h3>See also:</h3>
 <p><a href="index.html">snapplot</a></p>
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapspec/algorithm.html
+++ b/src/help/help/programs/snapspec/algorithm.html
@@ -137,5 +137,6 @@ no coordinates are failed by this test.</li>
 <p><a href="configuration.html">snapspec configuration file</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapspec/configuration.html
+++ b/src/help/help/programs/snapspec/configuration.html
@@ -262,5 +262,6 @@ log_level steps test_details
 <p><a href="index.html">snapspec</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/programs/snapspec/index.html
+++ b/src/help/help/programs/snapspec/index.html
@@ -155,5 +155,6 @@ file.
 <p><a href="../../files/cmdcfg/index.html">command files</a></p>
 
 </div>
+<script src="../../js/helppage.js"></script>
 </body>
 </html>

--- a/src/help/help/snap.html
+++ b/src/help/help/snap.html
@@ -58,5 +58,6 @@ computer.  Perl for windows can be obtained from <a href="http://www.strawberryp
 <p><a href="files/index.html">Files used by SNAP</a></p>
 
 </div>
+<script src="js/helppage.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- The help viewer's sidebar/search navigation loads pages into an iframe, but the outer address bar never reflected which page was showing, and there was no way to step back through pages already visited.
- Every content page now announces its own URL to the shell via `postMessage` on load, which the shell uses to label the browser's own history entry (`history.replaceState`) and highlight the right sidebar item — covering sidebar clicks, search results, and in-page content links uniformly, since the browser already creates its own history entry for each iframe navigation regardless of what triggered it.
- This also lays the groundwork for more structural additions, such as a breadcrumb trail, since the shell now has a single, reliable signal for which page is currently showing regardless of how the user navigated there.

## Test plan

- [x] Open `src/help/help/index.html` directly in a browser
- [x] Click a sidebar link — confirm the address bar updates to `?<page>.html` and the sidebar highlights the right item
- [x] Click a search result — same check
- [x] Click a cross-reference link inside a content page (not via the sidebar) — confirm the address bar and sidebar highlight still update
- [x] Use Back/Forward — confirm both the address bar and the displayed page step through history correctly in both directions
- [x] Verified in both Chrome and Firefox

[GSR-996](https://toitutewhenua.atlassian.net/browse/GSR-996)

[GSR-996]: https://toitutewhenua.atlassian.net/browse/GSR-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ