### PR TITLE
feat: add tri-state master checkbox to snapplot Key panel colour-coding lists

### DIFF
--- a/src/snapplot/snapplot_layers.cpp
+++ b/src/snapplot/snapplot_layers.cpp
@@ -66,6 +66,7 @@ static int station_layers_pens[] = {FREE_STN_PEN,FREE_STN_PEN,HOR_FIXED_STN_PEN,
 
 static layer_s station_layers[] =
 {
+    {"Station types",UNUSED_PEN_ID,OTHER_OPT,0,true,false,false,false,-1,true},
     {"Free stations",FREE_STN_PEN,FREE_STN_OPT,"GREY",true,false,false,false,-1},
     {"Fixed stations",FIXED_STN_PEN,FIXED_STN_OPT,"RED",true,true,true,false,-1},
     {"Hor fixed stns",HOR_FIXED_STN_PEN,HOR_FIXED_STN_OPT,"RED",true,true,false,false,-1},
@@ -75,6 +76,7 @@ static layer_s station_layers[] =
     {"Name",UNUSED_PEN_ID, NAME_OPT,0,false,false,false,false,-1},
     {"Code",UNUSED_PEN_ID, CODE_OPT,0,false,false,false,false,-1},
     {"",UNUSED_PEN_ID,UNUSED_OPT_ID,0,false,false,false,false,-1},
+    {"Station metrics",UNUSED_PEN_ID,OTHER_OPT,0,true,false,false,false,-1,true},
     {"Error ellipses",ELLIPSE_PEN,ELLIPSE_OPT,"SEA GREEN",true,true,false,true,-1},
     {"Relative ellipse",REL_ELL_PEN, REL_ELL_OPT,"SEA GREEN",false,true,false,true,-1},
     {"Hor adjustment",HOR_ADJ_PEN,HOR_ADJ_OPT,"RED",false,true,false,true,-1},
@@ -91,6 +93,7 @@ static layer_s *data_type_layers = 0;
 
 static layer_s data_usage_layers[] =
 {
+    {"Obs status",UNUSED_PEN_ID,OTHER_OPT,0,true,false,false,false,-1,true},
     {"Used obs",UNUSED_PEN_ID, USED_OBS_OPT,0,true,false,false,false,-1},
     {"Rejected obs",UNUSED_PEN_ID, REJECTED_OBS_OPT,0,true,false,false,false,-1},
     {"Unused obs",UNUSED_PEN_ID, UNUSED_OBS_OPT,0,true,false,false,false,-1},
@@ -264,7 +267,8 @@ static void set_station_layer_colourflag( bool on )
 {
     for( int i = 0; station_layers_pens[i] >= 0; i++ )
     {
-        station_layers[i].pen_id = on ? station_layers_pens[i] : UNUSED_PEN_ID;
+        // i+1 to skip the "Station types" header row added at index 0
+        station_layers[i+1].pen_id = on ? station_layers_pens[i] : UNUSED_PEN_ID;
     }
 }
 
@@ -280,6 +284,8 @@ static void setup_station_class_layers( int class_id )
         station_user_layers = (layer_s *) check_malloc( sizeof(layer_s) * (nlayer+2) );
         layer_s *l = &(station_user_layers[0]);
         init_layer( l, network_class_name(net, class_id), dflt_data_colour, true );
+        l->opt_id = OTHER_OPT;
+        l->is_control_checkbox = true;
         for( int i = 0; i < nlayer; i++ )
         {
             char buf[256];
@@ -316,10 +322,10 @@ static void set_datatype_layer_colourflag( bool on )
 {
     setup_data_type_layers();
     if( ! data_type_layers ) return;
-    // on means "Data type" is the active colour-coding mode: show the header row
-    // with its control checkbox. Otherwise (Data file/Residual/Redundancy active
-    // instead) drop the header row entirely, as before this feature existed.
-    data_type_layers[0].pen_id = on ? UNUSED_PEN_ID : UNUSED_LAYER_PEN_ID;
+    // The header row and its control checkbox are shown whether or not "Data type"
+    // is the active colour-coding mode; only the colour swatches on the rows below
+    // it depend on on/off.
+    data_type_layers[0].pen_id = UNUSED_PEN_ID;
     for( int i = 0; i < NOBSTYPE; i++ )
     {
         // i+1 to skip the header row added at index 0

--- a/src/snapplot/snapplot_layers.cpp
+++ b/src/snapplot/snapplot_layers.cpp
@@ -55,6 +55,9 @@ struct layer_s
     bool need_vrt;
     bool need_cvr;
     int lyr_id;
+    // true if this row's checkbox is to control a following range of
+    // other rows' status, instead of its own
+    bool is_control_checkbox = false;
 };
 
 static layer_s *station_user_layers = 0;
@@ -254,6 +257,7 @@ static void init_layer( layer_s *l, const char *name, const char *colour, bool t
     l->need_vrt = false;
     l->need_cvr = false;
     l->lyr_id = -1;
+    l->is_control_checkbox = false;
 }
 
 static void set_station_layer_colourflag( bool on )
@@ -291,25 +295,37 @@ static void setup_station_class_layers( int class_id )
 static void setup_data_type_layers()
 {
     if( data_type_layers ) return;
-    data_type_layers = (layer_s *) check_malloc( sizeof(layer_s) * (NOBSTYPE + 1) );
+    // NOBSTYPE data rows + 1 header/control-checkbox row (index 0) + 1 terminator (name=0)
+    data_type_layers = (layer_s *) check_malloc( sizeof(layer_s) * (NOBSTYPE + 2) );
+    layer_s *l = &(data_type_layers[0]);
+    init_layer(l,"Data type",dflt_data_colour,true);
+    l->opt_id = OTHER_OPT;
+    l->is_control_checkbox = true;
     for( int itype = 0; itype<NOBSTYPE; itype++ )
     {
-        layer_s *l = &(data_type_layers[itype]);
+        // itype+1 into data_type_layers to skip the header row; datatype[]/obstypecount[]
+        // have no header row of their own, so they stay indexed by the plain itype
+        l = &(data_type_layers[itype+1]);
         init_layer(l,datatype[itype].name,dflt_data_colour, 0 );
         if( obstypecount[itype] == 0 ) l->pen_id = UNUSED_LAYER_PEN_ID;
     }
-    data_type_layers[NOBSTYPE].name = 0;
+    data_type_layers[NOBSTYPE+1].name = 0;
 }
 
 static void set_datatype_layer_colourflag( bool on )
 {
     setup_data_type_layers();
     if( ! data_type_layers ) return;
+    // on means "Data type" is the active colour-coding mode: show the header row
+    // with its control checkbox. Otherwise (Data file/Residual/Redundancy active
+    // instead) drop the header row entirely, as before this feature existed.
+    data_type_layers[0].pen_id = on ? UNUSED_PEN_ID : UNUSED_LAYER_PEN_ID;
     for( int i = 0; i < NOBSTYPE; i++ )
     {
-        if( data_type_layers[i].pen_id != UNUSED_LAYER_PEN_ID )
+        // i+1 to skip the header row added at index 0
+        if( data_type_layers[i+1].pen_id != UNUSED_LAYER_PEN_ID )
         {
-            data_type_layers[i].pen_id = on ? OTHER_PEN : UNUSED_PEN_ID;
+            data_type_layers[i+1].pen_id = on ? OTHER_PEN : UNUSED_PEN_ID;
         }
     }
 }
@@ -324,6 +340,8 @@ void setup_data_pens_layers( int ndatapens, const char **datapennames, const cha
     data_user_layers = (layer_s *) check_malloc( sizeof(layer_s) * (ndatapens+2) );
     layer_s *l = &(data_user_layers[0]);
     init_layer(l,header,dflt_data_colour,true);
+    l->opt_id = OTHER_OPT;
+    l->is_control_checkbox = true;
     for( int i = 0; i < ndatapens; i++ )
     {
         l = &(data_user_layers[i+1]);
@@ -378,7 +396,7 @@ static void add_layer_to_symbology( Symbology *symbology, layer_s *l, Symbology 
     wxColour colour = wxColour( l->dfltColour );
     bool display = true;
 
-    l->lyr_id = symbology->AddLayer( l->name, type, colour, display );
+    l->lyr_id = symbology->AddLayer( l->name, type, colour, display, l->is_control_checkbox );
     if( oldSymbology && oldid >= 0 ) copy_layer( symbology, l->lyr_id, oldSymbology, oldid );
 
     if( l->pen_id >= 0 ) basepenid[l->pen_id] = l->lyr_id;
@@ -644,7 +662,8 @@ int data_pen( int dpen )
     }
     else
     {
-        lyr_id = data_type_layers[dpen].lyr_id;
+        // dpen+1 to account for header layer..
+        lyr_id = data_type_layers[dpen+1].lyr_id;
     }
     return lyr_id;
 }
@@ -659,7 +678,8 @@ int pen_selected( int pen )
 int datatype_selected( int datatype )
 {
     int lyrid;
-    lyrid = data_type_layers[datatype].lyr_id;
+    // datatype+1 to account for header layer..
+    lyrid = data_type_layers[datatype+1].lyr_id;
     return pen_selected( lyrid );
 }
 

--- a/src/wxutils/wxlayerkey.cpp
+++ b/src/wxutils/wxlayerkey.cpp
@@ -167,16 +167,12 @@ BEGIN_EVENT_TABLE(wxLayerKey, wxGrid)
     EVT_GRID_CELL_LEFT_CLICK( wxLayerKey::OnLeftClick )
 END_EVENT_TABLE()
 
-wxLayerKey::wxLayerKey() :
-    masterRow(-1),
-    masterLastChild(-1)
+wxLayerKey::wxLayerKey()
 {
 }
 
 wxLayerKey::wxLayerKey(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size ) :
-    wxGrid( parent, id, pos, size ),
-    masterRow(-1),
-    masterLastChild(-1)
+    wxGrid( parent, id, pos, size )
 {
     long style = GetWindowStyleFlag();
     style &= ! wxHSCROLL;
@@ -212,8 +208,7 @@ void wxLayerKey::SetSymbology( Symbology *newSymbologyKey )
 
     if( GetNumberRows() > 0 ) DeleteRows( 0, GetNumberRows() );
 
-    masterRow = -1;
-    masterLastChild = -1;
+    masterRanges.clear();
 
     if( symbologyKey->LayerCount() > 0 )
     {
@@ -256,22 +251,28 @@ void wxLayerKey::SetSymbology( Symbology *newSymbologyKey )
         SetColSize( 0, symbologyKey->PaletteBitmapSize() + 6 );
         SetColSize( 1, wxBitmapGridRenderer::TickBitmapSize() + 6 );
 
-        // Locate the (at most one) control checkbox row and the range of ordinary
-        // status rows it controls, once here rather than on every click.
+        // Locate every control checkbox row and the range of ordinary status rows
+        // each controls, once here rather than on every click. A symbology can
+        // contain more than one (two colour-coding lists can both show a header
+        // at once), so a non-status row such as a spacer only ends the range
+        // currently being extended - it doesn't stop the search for further
+        // control checkbox rows after it.
+        int current = -1;
         for( int i = 0; i < symbologyKey->LayerCount(); i++ ) {
             LayerSymbology &sym = symbologyKey->GetLayer( i );
             if( sym.IsControlCheckbox() ) {
-                masterRow = i;
-                masterLastChild = i;
+                masterRanges.push_back( MasterRange{ i, i } );
+                current = (int) masterRanges.size() - 1;
                 continue;
             }
-            if( masterRow < 0 ) {
+            if( current < 0 ) {
                 continue;
             }
             if( ! sym.HasStatus() ) {
-                break;
+                current = -1;
+                continue;
             }
-            masterLastChild = i;
+            masterRanges[current].lastChild = i;
         }
     }
 }
@@ -303,31 +304,34 @@ void wxLayerKey::OnLeftClick( wxGridEvent &event )
     else if( event.GetCol() == 1 ) {
         const int row = event.GetRow();
         LayerSymbology &sym = symbologyKey->GetLayer( row );
-        if( row == masterRow ) {
+        const MasterLookup lookup = FindMasterRange( row );
+        if( lookup.isMaster ) {
             // Clicking the master control while it's indeterminate or unchecked
             // selects every child row below it; clicking it while checked deselects
             // them all. The master itself can never end up indeterminate directly
             // from its own click - only from an individual child edit.
+            const MasterRange &range = masterRanges[lookup.rangeIndex];
             const bool checkAll = sym.IsMixedRowStatus() || ! sym.Status();
-            for( int i = masterRow+1; i <= masterLastChild; i++ ) {
+            for( int i = range.master+1; i <= range.lastChild; i++ ) {
                 symbologyKey->GetLayer( i ).SetStatus( checkAll );
             }
             sym.SetStatus( checkAll );
             sym.SetMixedRowStatus( false );
-            wxGridCellCoords topLeft( masterRow, event.GetCol() );
-            wxGridCellCoords bottomRight( masterLastChild, event.GetCol() );
+            wxGridCellCoords topLeft( range.master, event.GetCol() );
+            wxGridCellCoords bottomRight( range.lastChild, event.GetCol() );
             RefreshRect( BlockToDeviceRect( topLeft, bottomRight ) );
             FireSymbologyChangedEvent();
         } else if( sym.HasStatus() ) {
             sym.SetStatus( ! sym.Status() );
             wxGridCellCoords cell( row, event.GetCol() );
             RefreshRect( BlockToDeviceRect( cell, cell) );
-            // Any time a single child row is clicked, the master control turns
-            // indeterminate to show its children no longer agree, no matter which
-            // way that child was toggled or what state the master was in before.
-            // It stays indeterminate until the user clicks the master control
-            // directly.
-            if( masterRow >= 0 && row > masterRow && row <= masterLastChild ) {
+            // Any time a single child row is clicked, the master control that owns
+            // it turns indeterminate to show its children no longer agree, no
+            // matter which way that child was toggled or what state the master was
+            // in before. It stays indeterminate until the user clicks the master
+            // control directly.
+            if( lookup.rangeIndex >= 0 ) {
+                const int masterRow = masterRanges[lookup.rangeIndex].master;
                 symbologyKey->GetLayer( masterRow ).SetMixedRowStatus( true );
                 wxGridCellCoords masterCell( masterRow, event.GetCol() );
                 RefreshRect( BlockToDeviceRect( masterCell, masterCell ) );
@@ -335,6 +339,19 @@ void wxLayerKey::OnLeftClick( wxGridEvent &event )
             FireSymbologyChangedEvent();
         }
     }
+}
+
+wxLayerKey::MasterLookup wxLayerKey::FindMasterRange( const int row ) const
+{
+    for( size_t r = 0; r < masterRanges.size(); r++ ) {
+        if( masterRanges[r].master == row ) {
+            return MasterLookup{ (int) r, true };
+        }
+        if( row > masterRanges[r].master && row <= masterRanges[r].lastChild ) {
+            return MasterLookup{ (int) r, false };
+        }
+    }
+    return MasterLookup{ -1, false };
 }
 
 // Crude mechanism to disable cell selection (for visual effect).

--- a/src/wxutils/wxlayerkey.cpp
+++ b/src/wxutils/wxlayerkey.cpp
@@ -8,6 +8,7 @@
 #include "wxlayerkey.hpp"
 #include "wxsimpleevent.hpp"
 #include "wxpalettepopup.hpp"
+#include <wx/renderer.h>
 
 DEFINE_EVENT_TYPE(WX_SYMBOLOGY_CHANGED)
 
@@ -108,6 +109,13 @@ void wxBitmapGridRenderer::Draw( wxGrid& grid, wxGridCellAttr& attr, wxDC& dc, c
     {
         LayerSymbology &sym = symkey->GetLayer( row );
 
+        if( col == 1 && sym.IsControlCheckbox() ) {
+            const int flags = sym.IsMixedRowStatus() ? wxCONTROL_UNDETERMINED :
+                               sym.Status() ? wxCONTROL_CHECKED : wxCONTROL_NONE;
+            wxRendererNative::Get().DrawCheckBox( &grid, dc, rect, flags );
+            return;
+        }
+
         const wxBitmap *bmp = 0;
         if( col  == 0 && sym.HasColour() )
         {
@@ -159,12 +167,16 @@ BEGIN_EVENT_TABLE(wxLayerKey, wxGrid)
     EVT_GRID_CELL_LEFT_CLICK( wxLayerKey::OnLeftClick )
 END_EVENT_TABLE()
 
-wxLayerKey::wxLayerKey()
+wxLayerKey::wxLayerKey() :
+    masterRow(-1),
+    masterLastChild(-1)
 {
 }
 
 wxLayerKey::wxLayerKey(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size ) :
-    wxGrid( parent, id, pos, size )
+    wxGrid( parent, id, pos, size ),
+    masterRow(-1),
+    masterLastChild(-1)
 {
     long style = GetWindowStyleFlag();
     style &= ! wxHSCROLL;
@@ -199,6 +211,9 @@ void wxLayerKey::SetSymbology( Symbology *newSymbologyKey )
     // rendering
 
     if( GetNumberRows() > 0 ) DeleteRows( 0, GetNumberRows() );
+
+    masterRow = -1;
+    masterLastChild = -1;
 
     if( symbologyKey->LayerCount() > 0 )
     {
@@ -240,6 +255,24 @@ void wxLayerKey::SetSymbology( Symbology *newSymbologyKey )
         AutoSizeColumns();
         SetColSize( 0, symbologyKey->PaletteBitmapSize() + 6 );
         SetColSize( 1, wxBitmapGridRenderer::TickBitmapSize() + 6 );
+
+        // Locate the (at most one) control checkbox row and the range of ordinary
+        // status rows it controls, once here rather than on every click.
+        for( int i = 0; i < symbologyKey->LayerCount(); i++ ) {
+            LayerSymbology &sym = symbologyKey->GetLayer( i );
+            if( sym.IsControlCheckbox() ) {
+                masterRow = i;
+                masterLastChild = i;
+                continue;
+            }
+            if( masterRow < 0 ) {
+                continue;
+            }
+            if( ! sym.HasStatus() ) {
+                break;
+            }
+            masterLastChild = i;
+        }
     }
 }
 
@@ -267,14 +300,38 @@ void wxLayerKey::OnLeftClick( wxGridEvent &event )
             }
         }
     }
-    else if( event.GetCol() == 1 )
-    {
-        LayerSymbology &sym = symbologyKey->GetLayer( event.GetRow() );
-        if( sym.HasStatus() )
-        {
+    else if( event.GetCol() == 1 ) {
+        const int row = event.GetRow();
+        LayerSymbology &sym = symbologyKey->GetLayer( row );
+        if( row == masterRow ) {
+            // Clicking the master control while it's indeterminate or unchecked
+            // selects every child row below it; clicking it while checked deselects
+            // them all. The master itself can never end up indeterminate directly
+            // from its own click - only from an individual child edit.
+            const bool checkAll = sym.IsMixedRowStatus() || ! sym.Status();
+            for( int i = masterRow+1; i <= masterLastChild; i++ ) {
+                symbologyKey->GetLayer( i ).SetStatus( checkAll );
+            }
+            sym.SetStatus( checkAll );
+            sym.SetMixedRowStatus( false );
+            wxGridCellCoords topLeft( masterRow, event.GetCol() );
+            wxGridCellCoords bottomRight( masterLastChild, event.GetCol() );
+            RefreshRect( BlockToDeviceRect( topLeft, bottomRight ) );
+            FireSymbologyChangedEvent();
+        } else if( sym.HasStatus() ) {
             sym.SetStatus( ! sym.Status() );
-            wxGridCellCoords cell( event.GetRow(), event.GetCol() );
+            wxGridCellCoords cell( row, event.GetCol() );
             RefreshRect( BlockToDeviceRect( cell, cell) );
+            // Any time a single child row is clicked, the master control turns
+            // indeterminate to show its children no longer agree, no matter which
+            // way that child was toggled or what state the master was in before.
+            // It stays indeterminate until the user clicks the master control
+            // directly.
+            if( masterRow >= 0 && row > masterRow && row <= masterLastChild ) {
+                symbologyKey->GetLayer( masterRow ).SetMixedRowStatus( true );
+                wxGridCellCoords masterCell( masterRow, event.GetCol() );
+                RefreshRect( BlockToDeviceRect( masterCell, masterCell ) );
+            }
             FireSymbologyChangedEvent();
         }
     }

--- a/src/wxutils/wxlayerkey.hpp
+++ b/src/wxutils/wxlayerkey.hpp
@@ -10,6 +10,8 @@
 #include "wx_includes.hpp"
 #include "wxsymbology.hpp"
 
+#include <vector>
+
 DECLARE_EVENT_TYPE(WX_SYMBOLOGY_CHANGED, -1)
 
 class wxLayerKey : public wxGrid
@@ -30,11 +32,27 @@ private:
     Symbology *symbologyKey;
     void FireSymbologyChangedEvent();
 
-    // Row holding the active control checkbox, or -1 if the current symbology has none.
+    // A control checkbox row and the range of ordinary status rows below it that
+    // it controls (inclusive). A symbology can contain more than one of these
+    // (e.g. the Data type list and the Data file/Residual/Redundancy list can
+    // both show a header at once), so every one found is kept, not just the first.
+    struct MasterRange
+    {
+        int master;
+        int lastChild;
+    };
     // Recomputed by SetSymbology(), not on every click.
-    int masterRow;
-    // Last row controlled by masterRow (inclusive). Meaningless if masterRow < 0.
-    int masterLastChild;
+    std::vector<MasterRange> masterRanges;
+
+    // Result of looking up which masterRanges entry a row belongs to, as either
+    // the master itself or one of its children. rangeIndex is -1 if row is not
+    // part of any range, in which case isMaster is meaningless.
+    struct MasterLookup
+    {
+        int rangeIndex;
+        bool isMaster;
+    };
+    MasterLookup FindMasterRange( int row ) const;
 
     DECLARE_DYNAMIC_CLASS( wxLayerKey );
     DECLARE_EVENT_TABLE();

--- a/src/wxutils/wxlayerkey.hpp
+++ b/src/wxutils/wxlayerkey.hpp
@@ -30,6 +30,12 @@ private:
     Symbology *symbologyKey;
     void FireSymbologyChangedEvent();
 
+    // Row holding the active control checkbox, or -1 if the current symbology has none.
+    // Recomputed by SetSymbology(), not on every click.
+    int masterRow;
+    // Last row controlled by masterRow (inclusive). Meaningless if masterRow < 0.
+    int masterLastChild;
+
     DECLARE_DYNAMIC_CLASS( wxLayerKey );
     DECLARE_EVENT_TABLE();
 

--- a/src/wxutils/wxsymbology.cpp
+++ b/src/wxutils/wxsymbology.cpp
@@ -229,11 +229,13 @@ int SymbologyList::GetSymbologyByIdentifier( wxString uid ) const
 
 // LayerSymbology. Simple class defining a symbology.
 
-LayerSymbology::LayerSymbology(wxString name, int type, int colourId, bool show) :
+LayerSymbology::LayerSymbology(wxString name, int type, int colourId, bool show, const bool isControlCheckbox) :
     SymbologyBase(name),
     type(type),
     colourId(colourId),
-    show(show)
+    show(show),
+    isControlCheckbox(isControlCheckbox),
+    mixedRowStatus(false)
 {
 }
 
@@ -286,6 +288,21 @@ bool LayerSymbology::HasColour() const
 bool LayerSymbology::HasStatus() const
 {
     return (type & hasStatus) == hasStatus;
+}
+
+bool LayerSymbology::IsControlCheckbox() const
+{
+    return isControlCheckbox;
+}
+
+bool LayerSymbology::IsMixedRowStatus() const
+{
+    return mixedRowStatus;
+}
+
+void LayerSymbology::SetMixedRowStatus( const bool newMixedRowStatus )
+{
+    mixedRowStatus = newMixedRowStatus;
 }
 
 // TextAlign: A class for rendering text at a specified offset relative to a point.
@@ -536,11 +553,11 @@ void Symbology::InitialisePalette( const ColourPalette &basepalette )
     }
 }
 
-int Symbology::AddLayer(wxString name, int type, const wxColour &colour, bool display )
+int Symbology::AddLayer(wxString name, int type, const wxColour &colour, bool display, const bool isControlCheckbox )
 {
     int colourId = 0;
     if( colour.IsOk() ) colourId= palette.AddColour( colour );
-    LayerSymbology *s = new LayerSymbology( name, type, colourId, display );
+    LayerSymbology *s = new LayerSymbology( name, type, colourId, display, isControlCheckbox );
     return layers.AddSymbology( s );
 }
 

--- a/src/wxutils/wxsymbology.hpp
+++ b/src/wxutils/wxsymbology.hpp
@@ -103,7 +103,7 @@ class LayerSymbology : public SymbologyBase
 public:
     enum Type { label = 0, hasColour = 1, hasStatus = 2, hasColourAndStatus = 3 };
 
-    LayerSymbology( wxString name, int type, int colourId, bool show );
+    LayerSymbology( wxString name, int type, int colourId, bool show, bool isControlCheckbox = false );
     int Type() const;
     int ColourId() const;
     void SetColourId( int newColourId );
@@ -112,10 +112,20 @@ public:
     void SetStatus( bool newStatus );
     bool HasColour() const;
     bool HasStatus() const;
+    bool IsControlCheckbox() const;
+    bool IsMixedRowStatus() const;
+    void SetMixedRowStatus( bool newMixedRowStatus );
 private:
     int type;
     int colourId;
     bool show;
+    // true if this row's checkbox controls a following range of
+    // other rows' status, instead of its own
+    bool isControlCheckbox;
+    // when isControlCheckbox, true forces this row's checkbox glyph
+    // indeterminate, overriding the checked/unchecked mark show would
+    // otherwise draw; else unused
+    bool mixedRowStatus;
 };
 
 
@@ -208,7 +218,7 @@ public:
     ColourPalette *GetPalette() { return &palette ; }
     void InitialisePalette( const ColourPalette &basepalette );
 
-    int AddLayer( wxString name, int type, const wxColour &colour, bool display = true );
+    int AddLayer( wxString name, int type, const wxColour &colour, bool display = true, bool isControlCheckbox = false );
     void AddTitle(wxString name);
     void AddSpacer();
     int LayerCount() const;


### PR DESCRIPTION
## Summary
Adds a master/select-all checkbox to the header row of whichever list in
snapplot's Key panel currently shows per-item colour swatches — "Data type",
or "Data file"/"Residual"/"Redundancy" depending on the active colour-coding
mode. Only the active list gets a header row with a control checkbox; the
secondary (typically "Data type") list's header is omitted, matching its prior
behaviour.

I have used the default system checkbox rather than trying to match the current
style - I felt that it help distinguish the behaviour better. But am happy to 
re-implement if desired.

Behaviour:
- Starts solid checked, matching the children's default-on state.
- Any individual child click turns the master indeterminate, regardless of
  the master's previous state or which way the child was toggled.
- Clicking the master while indeterminate or unchecked checks every child;
  clicking it while checked unchecks every child. The master can never be
  clicked directly into the indeterminate state.

## Screenshots

All checked:

<img width="1868" height="1148" alt="all" src="https://github.com/user-attachments/assets/6a5ef143-98b4-4c69-ab1c-191920a42d82" />

None checked:

<img width="1866" height="1147" alt="none" src="https://github.com/user-attachments/assets/1cd195b6-3f39-4e24-b614-40a1b983e147" />

Some checked (indeterminate):

<img width="1867" height="1146" alt="some" src="https://github.com/user-attachments/assets/17cec106-6a1e-4af0-bea0-149e252ca548" />

[GSR-997](https://toitutewhenua.atlassian.net/browse/GSR-997)

[GSR-997]: https://toitutewhenua.atlassian.net/browse/GSR-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ