### PR TITLE
fix: update the grid file format description

### DIFF
--- a/src/help/help/coordsys/linzdeffile.html
+++ b/src/help/help/coordsys/linzdeffile.html
@@ -80,7 +80,7 @@ possible values are</p>
 <td>Big endian binary format - version 3</td>
 </tr>
 <tr>
-<td>LINDEF2L</td>
+<td>LINZDEF3L</td>
 <td>Little endian binary format - version 3 (the preferred format for
 SNAP)</td>
 </tr>
@@ -89,7 +89,7 @@ SNAP)</td>
 <td>Big endian binary format - version 2</td>
 </tr>
 <tr>
-<td>LINDEF2L</td>
+<td>LINZDEF2L</td>
 <td>Little endian binary format - version 2</td>
 </tr>
 <tr>
@@ -97,7 +97,7 @@ SNAP)</td>
 <td>Big endian binary format version 1</td>
 </tr>
 <tr>
-<td>LINDEF1L</td>
+<td>LINZDEF1L</td>
 <td>Little endian binary format version 1</td>
 </tr>
 </table>

--- a/src/help/help/files/file_formats.html
+++ b/src/help/help/files/file_formats.html
@@ -49,7 +49,7 @@
 
 <tr>
 <td><a href="../coordsys/gridfile_s.html">Grid file format</a></td>
-<td>A gridded data file used for geoid or deformation models in SNAP and concord.</td>
+<td>A gridded data file used for geoid models, as a standalone velocity-based deformation model, or as a component of a LINZ deformation model (see <a href="../coordsys/linzdeffile.html">LINZ deformation file format</a>) in SNAP and concord.</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
Add a little more detail to help better distinguish it from the "LINZ deformation file format".