### PR TITLE
fix: give error ellipses, height errors, and adjustment vectors independent auto-scales

### DIFF
--- a/src/snapplot/dlg_error_options.cpp
+++ b/src/snapplot/dlg_error_options.cpp
@@ -69,12 +69,11 @@ void ErrorOptionsDialog::Apply()
     errconflim=useConfLimit ? 1 : 0;
     errconfval=confLimit;
     set_confidence_limit();
-    double dfltscl = calc_default_error_scale();
     double scl = horErrorFactor;
-    if( horAutoScale ) scl = 1.1 * scl / dfltscl;
+    if( horAutoScale ) scl = 1.1 * scl / calc_default_error_scale();
     set_errell_exaggeration( scl, horAutoScale ? 1 : 0 );
     scl = vrtErrorFactor;
-    if( vrtAutoScale ) scl = 1.1 * scl / dfltscl;
+    if( vrtAutoScale ) scl = 1.1 * scl / calc_default_height_error_scale();
     set_hgterr_exaggeration( scl, vrtAutoScale ? 1 : 0 );
 }
 

--- a/src/snapplot/plotconn.cpp
+++ b/src/snapplot/plotconn.cpp
@@ -1197,7 +1197,7 @@ int plot_connections( map_plotter *plotter, int first, int offset_opt, double of
     {
         ellpen = get_pen( REL_ELL_PEN );
         if( !pen_visible(ellpen) ) pltrelerr = 0;
-        eemult = errell_factor * errell_scale;
+        eemult = errell_factor * rel_errell_scale;
     }
 
     pltrelhgt = option_selected( REL_HGT_OPT );
@@ -1468,7 +1468,7 @@ int plot_connections( map_plotter *plotter, int first, int offset_opt, double of
             if( pltrelhgt && cvr.sehgt > 0.0 )
             {
 
-                double he = cvr.sehgt  * hgterr_factor * hgterr_scale;
+                double he = cvr.sehgt  * hgterr_factor * rel_hgterr_scale;
 
                 if( he > 0 )
                 {

--- a/src/snapplot/plotscal.cpp
+++ b/src/snapplot/plotscal.cpp
@@ -36,6 +36,8 @@ void init_plot_scales( void )
     set_stn_symbol_size( 1.0, 1 );
     set_errell_exaggeration( 1.0, 1 );
     set_hgterr_exaggeration( 1.0, 1 );
+    adjhor_scale = 1.0;
+    adjvrt_scale = 1.0;
     /*
     apriori=program_mode == PREANALYSIS ? 1 : 0;
     errconflim=0;
@@ -215,47 +217,66 @@ static double nice_number( double value )
     return nice * *best;
 }
 
+typedef void (*component_func)( double *h, double *v );
+
+// Shared by every calc_default_*_scale() function below. componentFunc supplies
+// the raw horizontal/vertical magnitude (max_covariance_component,
+// maximum_relative_covariance, or max_adjustment_component); useHorizontal picks
+// which of the two to scale for; factor is the confidence-interval multiplier to
+// apply (1.0 for adjustment vectors, which have no such concept). The result
+// makes that single magnitude span about 1/20th of the visible plot extent.
+static double component_scale( const component_func componentFunc, const bool useHorizontal, const double factor )
+{
+    if( !got_covariances() ) return 0.0;
+    double h, v;
+    componentFunc( &h, &v );
+    const double cvrmax = (useHorizontal ? h : v) * factor;
+    const double safeCvrmax = cvrmax > 0 ? cvrmax : 1.0;
+    return (plot_emax - plot_emin + plot_nmax - plot_nmin) /
+           (20.0 * safeCvrmax);
+}
+
 double calc_default_error_scale( void )
 {
-    double dfltscale;
-    double cvrmax;
-    double h, v;
+    return component_scale( max_covariance_component, true, errell_factor );
+}
 
-    if( !got_covariances() ) return 0.0;
-    cvrmax = 0.0;
-    max_covariance_component( &h, &v );
-    if( option_selected(ELLIPSE_OPT) && h > cvrmax ) cvrmax = h;
-    if( option_selected(HGTERR_OPT)  && v > cvrmax ) cvrmax = v;
-    maximum_relative_covariance( &h, &v );
-    if( option_selected(REL_ELL_OPT) && h > cvrmax ) cvrmax = h;
-    if( option_selected(REL_HGT_OPT) && v > cvrmax ) cvrmax = v;
+double calc_default_relative_ellipse_scale( void )
+{
+    return component_scale( maximum_relative_covariance, true, errell_factor );
+}
 
-    if( errell_factor > hgterr_factor )
-    {
-        cvrmax *= errell_factor;
-    }
-    else
-    {
-        cvrmax *= hgterr_factor;
-    }
+double calc_default_height_error_scale( void )
+{
+    return component_scale( max_covariance_component, false, hgterr_factor );
+}
 
-    max_adjustment_component( &h, &v );
-    if( option_selected(HOR_ADJ_OPT) && h > cvrmax ) cvrmax = h;
-    if( option_selected(HGT_ADJ_OPT) && v > cvrmax ) cvrmax = v;
+double calc_default_relative_height_scale( void )
+{
+    return component_scale( maximum_relative_covariance, false, hgterr_factor );
+}
 
-    if( cvrmax <= 0 ) cvrmax = 1.0;
-    dfltscale = (plot_emax - plot_emin + plot_nmax - plot_nmin) /
-                (20.0 * cvrmax);
-    return dfltscale;
+double calc_default_hor_adjustment_scale( void )
+{
+    return component_scale( max_adjustment_component, true, 1.0 );
+}
+
+double calc_default_vrt_adjustment_scale( void )
+{
+    return component_scale( max_adjustment_component, false, 1.0 );
 }
 
 
 static void autoscale_errors( void )
 {
-    double dfltscale;
-    dfltscale = calc_default_error_scale();
-    if( autoscale_ellipse ) errell_scale = nice_number( dfltscale * ell_autosf );
-    if( autoscale_hgterr ) hgterr_scale = nice_number( dfltscale * he_autosf );
+    if( autoscale_ellipse ) errell_scale = nice_number( calc_default_error_scale() * ell_autosf );
+    if( autoscale_hgterr ) hgterr_scale = nice_number( calc_default_height_error_scale() * he_autosf );
+
+    rel_errell_scale = nice_number( calc_default_relative_ellipse_scale() * ell_autosf );
+    rel_hgterr_scale = nice_number( calc_default_relative_height_scale() * he_autosf );
+
+    adjhor_scale = nice_number( calc_default_hor_adjustment_scale() * ell_autosf );
+    adjvrt_scale = nice_number( calc_default_vrt_adjustment_scale() * he_autosf );
 }
 
 

--- a/src/snapplot/plotscal.h
+++ b/src/snapplot/plotscal.h
@@ -20,6 +20,11 @@ void get_hgterr_exaggeration( double *scale, int *autoscl );
 void set_confidence_limit();
 double calc_default_stn_size( void );
 double calc_default_error_scale( void );
+double calc_default_relative_ellipse_scale( void );
+double calc_default_height_error_scale( void );
+double calc_default_relative_height_scale( void );
+double calc_default_hor_adjustment_scale( void );
+double calc_default_vrt_adjustment_scale( void );
 double calc_obs_offset( void );
 
 void init_plot_scales( void );
@@ -43,6 +48,17 @@ SCOPE double errell_factor;
 SCOPE double errell_scale;
 SCOPE double hgterr_factor;
 SCOPE double hgterr_scale;
+// Scale factor for "Relative ellipse", independent of errell_scale so that
+// toggling one doesn't resize the other.
+SCOPE double rel_errell_scale;
+// Scale factor for "Relative hgt err", independent of hgterr_scale for the same reason.
+SCOPE double rel_hgterr_scale;
+// Scale factors for the Hor/Vrt adjustment vectors, also independent of every
+// scale above: adjustment magnitudes are typically much larger than
+// covariance-based error magnitudes and would otherwise dominate a shared
+// auto-scale, or resize unrelated items, whenever more than one is selected.
+SCOPE double adjhor_scale;
+SCOPE double adjvrt_scale;
 SCOPE double confidence_limit;
 SCOPE char use_confidence_limit;
 SCOPE char aposteriori_errors;

--- a/src/snapplot/plotstns.cpp
+++ b/src/snapplot/plotstns.cpp
@@ -1592,9 +1592,9 @@ int plot_adjustments( map_plotter *plotter, int first )
 
         get_station_coordinates( istn, &x, &y );
 
-        dx = stns[istn].de * errell_scale;
-        dy = stns[istn].dn * errell_scale;
-        dh = stns[istn].dh * hgterr_scale;
+        dx = stns[istn].de * adjhor_scale;
+        dy = stns[istn].dn * adjhor_scale;
+        dh = stns[istn].dh * adjvrt_scale;
 
         if( plthor )
         {


### PR DESCRIPTION
`snapplot` computed one shared scale factor across error ellipses, height errors, relative ellipses/height errors, and Hor/Vrt adjustment vectors. It picked whichever selected quantity had the largest magnitude and calibrated to that. Adjustment vectors are typically far larger than covariance-based errors. Selecting both, the default, could leave the covariance-based ellipses effectively invisible. Toggling any one of the six could also visibly resize every other currently-displayed one, since they all shared the same scale.

Each of the six now gets its own independent scale, computed only from its own magnitude: `errell_scale`, `hgterr_scale`, `rel_errell_scale`, `rel_hgterr_scale`, `adjhor_scale`, `adjvrt_scale`. `errell_scale` and `hgterr_scale` keep their existing manual override via the Error options dialog. The other four are always auto-computed, same as before this change - none ever had their own manual control.

# Before
Screenshot snapped during some different work, this PR only affects what is displayed in the main window via the "Station metrics" checkboxes:

<img width="1867" height="1147" alt="before_station_metrics" src="https://github.com/user-attachments/assets/1d436eb3-2f1a-430a-b0f3-ee19881890f7" />

## After
<img width="1867" height="1148" alt="after_station_metrics" src="https://github.com/user-attachments/assets/4372af44-59fc-41ab-b6c3-f603712ebcf7" />

@ccrook - obviously let me know if there is some reason not to choose this method of resolution :)

[GSR-999](https://toitutewhenua.atlassian.net/browse/GSR-999)

[GSR-999]: https://toitutewhenua.atlassian.net/browse/GSR-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ