### PR TITLE
fix: reposition the colour swatch popup at the click point

### DIFF
--- a/src/wxutils/wxpalettepopup.cpp
+++ b/src/wxutils/wxpalettepopup.cpp
@@ -2,12 +2,16 @@
 
 #include "wxpalettepopup.hpp"
 
+#include <wx/evtloop.h>
+
 wxPalettePopup::wxPalettePopup( ColourPalette *thisPalette, wxWindow *parent, wxWindowID id ) :
-    wxDialog( parent, id, "", wxDefaultPosition, wxDefaultSize, wxSIMPLE_BORDER )
+    wxPopupTransientWindow( parent, wxBORDER_SIMPLE )
 {
+    SetId( id );
     SetExtraStyle( wxWS_EX_BLOCK_EVENTS );
     bitmapsize = 1;
     spacing = 3;
+    ignoreNextButtonUp = false;
     SetPalette( thisPalette );
     highlightColour.Set( 255, 127, 0 );
 }
@@ -16,10 +20,11 @@ wxPalettePopup::~wxPalettePopup()
 {
 }
 
-BEGIN_EVENT_TABLE( wxPalettePopup, wxWindow )
+BEGIN_EVENT_TABLE( wxPalettePopup, wxPopupTransientWindow )
     EVT_PAINT( wxPalettePopup::OnPaint )
     EVT_MOUSE_EVENTS( wxPalettePopup::OnMouseEvent )
     EVT_KEY_DOWN( wxPalettePopup::OnKeyDownEvent )
+    EVT_MOUSE_CAPTURE_LOST( wxPalettePopup::OnCaptureLost )
 END_EVENT_TABLE()
 
 void wxPalettePopup::SetPalette(ColourPalette *newPalette)
@@ -142,6 +147,15 @@ void wxPalettePopup::OnPaint( wxPaintEvent & WXUNUSED(event) )
 {
     wxPaintDC dc(this);
     dc.Clear();
+
+    // Drawn explicitly rather than relying on the wxBORDER_SIMPLE window style: the popup can
+    // sit right over the panel it opened from, and against a background the same colour, a
+    // native border isn't always visible enough to tell the two apart.
+    wxSize clientSize = GetClientSize();
+    dc.SetPen( wxSystemSettings::GetColour( wxSYS_COLOUR_3DSHADOW ) );
+    dc.SetBrush( *wxTRANSPARENT_BRUSH );
+    dc.DrawRectangle( 0, 0, clientSize.GetWidth(), clientSize.GetHeight() );
+
     if( palette )
     {
         for( int i = 0; i < palette->Size(); i++ )
@@ -171,7 +185,8 @@ void wxPalettePopup::OnMouseEvent( wxMouseEvent &event )
 
     if( event.ButtonDown() || event.ButtonUp() )
     {
-        EndModal(0);
+        if( IgnoreAsOpeningClick() ) return;
+        DismissAndNotify();
     }
 }
 
@@ -179,15 +194,67 @@ void wxPalettePopup::OnKeyDownEvent( wxKeyEvent &event )
 {
     if( event.GetKeyCode() == WXK_ESCAPE )
     {
-        EndModal(0);
+        DismissAndNotify();
     }
 }
 
+void wxPalettePopup::OnCaptureLost( wxMouseCaptureLostEvent & WXUNUSED(event) )
+{
+    if( IgnoreAsOpeningClick() ) return;
+    if( wxEventLoopBase::GetActive() ) wxEventLoopBase::GetActive()->Exit();
+}
+
+// True for exactly one event: either the button-up that ends the click that opened the popup
+// (tracked via ignoreNextButtonUp, however long that click is held), or, as a secondary safety
+// net, anything arriving in the first moment after showing, since capturing the mouse right
+// after showing can itself generate a spurious, immediate capture-lost notification.
+bool wxPalettePopup::IgnoreAsOpeningClick()
+{
+    bool ignore = ignoreNextButtonUp || ( wxGetLocalTimeMillis() - shownTime ) < 175;
+    ignoreNextButtonUp = false;
+    return ignore;
+}
+
+void wxPalettePopup::OnDismiss()
+{
+    if( wxEventLoopBase::GetActive() ) wxEventLoopBase::GetActive()->Exit();
+}
+
+// wxPopupTransientWindow isn't modal, so this blocks by running its own nested event loop
+// instead of ShowModal().  Popup()/DismissAndNotify() (called from OnMouseEvent/OnKeyDownEvent,
+// and automatically by wxPopupTransientWindow itself on an outside click or loss of focus) drive
+// OnDismiss(), which is the single place that exits the loop.
 bool wxPalettePopup::SelectColour( int &colourId )
 {
     selectedColour = colourId;
     PositionWindow();
-    ShowModal();
+    // "this" is safe to capture here since we don't return from this function until the popup
+    // is dismissed. We defer showing the popup (and capturing the mouse) until the next event
+    // loop iteration, rather than doing it directly from within the click that's opening it.
+    // We capture the mouse ourselves rather than relying only on wxPopupTransientWindow's own
+    // handling: where the popup overlaps a sibling panel like the map view, a click there can
+    // still be routed to that sibling by the OS's own hit-testing unless we hold the mouse the
+    // whole time we're shown.
+    CallAfter( [this]()
+    {
+        shownTime = wxGetLocalTimeMillis();
+        ignoreNextButtonUp = wxGetMouseState().LeftIsDown();
+        Popup();
+        CaptureMouse();
+    } );
+
+    // Deliberately not disabling the rest of the app (e.g. via wxWindowDisabler) while this runs.
+    // wxPopupTransientWindow dismisses itself when it loses activation to another top-level
+    // window, on Windows this is implemented as a deactivation notification, and a disabled
+    // window can't become active from a mouse click. Disabling the rest of the app would stop
+    // the user's click from ever reaching it, so the popup would never see that deactivation and
+    // would never dismiss on an outside click.
+    wxEventLoop loop;
+    loop.Run();
+
+    if( HasCapture() ) ReleaseMouse();
+    Hide();
+
     if( selectedColour < 0 ) selectedColour = colourId;
     bool colourChanged = selectedColour != colourId;
     colourId = selectedColour;

--- a/src/wxutils/wxpalettepopup.hpp
+++ b/src/wxutils/wxpalettepopup.hpp
@@ -1,18 +1,47 @@
 #ifndef WXPALETTEPOPUP_HPP
 #define WXPALETTEPOPUP_HPP
 
-// wxPalettePopup: A popup window for displaying a palette of colours.  This is a modal popup window that allows
-// for the selection of a colour.  It disappears on any mouse key event.  On a left mouse key event it selects the colour
-// under the mouse, if any.
+// wxPalettePopup: A popup window for displaying a palette of colours, allowing the selection
+// of a colour.  It closes on any mouse button event.  On a left mouse button event it selects
+// the colour under the mouse, if any.
 //
-// Requires a Symbology defining the symbologies to display, "tickon" and "tickoff" icons for
-// show/hide display.
+// This is built on wxPopupTransientWindow (a wxPopupWindow subclass) rather than wxDialog.
+// wxDialog::Move()/SetPosition() have no effect on the final on-screen position in this
+// environment: moving before showing, moving again after showing, deferring the move to the
+// next event loop iteration, and Center() followed by Move() were all tried and all failed
+// identically, with the window manager always recentering the dialog on its parent regardless.
+// wxPopupWindow is an override-redirect top-level window, the same kind used for menus and
+// combo popups, and it honours Move()/Position() reliably.
+//
+// wxPopupTransientWindow specifically (rather than plain wxPopupWindow) is used because it
+// already implements "close when the user loses focus to a different application", which
+// losing keyboard focus alone doesn't reliably give us for this kind of override-redirect
+// window. wxPopupTransientWindow is the same tested mechanism wxComboBox-style dropdown popups
+// rely on for that.
+//
+// We still capture the mouse ourselves (CaptureMouse()) rather than leaving all dismissal to
+// wxPopupTransientWindow: its own "click outside the popup" handling is activation-based, and
+// where the popup overlaps a sibling panel like the map view, the OS's own hit-testing can still
+// route a click there instead of to us unless we hold the mouse for as long as we're shown.
+//
+// The click that opens the popup is still in progress (button still down) at the point it
+// opens, since it's the very click wxLayerKey::OnLeftClick is handling. Its eventual button-up
+// (or, once we capture the mouse, sometimes a capture-lost notification instead) reaches the
+// popup regardless of how long the button is held, on both GTK and native Windows.
+// ignoreNextButtonUp records whether the button was already down when we were shown, so
+// OnMouseEvent()/OnCaptureLost() can recognise and ignore specifically that one event, rather
+// than an arbitrary time window that a slower, deliberate press could simply outlast.
+//
+// Since none of this is modal, SelectColour() runs its own nested event loop instead of using
+// ShowModal()/EndModal(), exited via OnDismiss().
 //
 
 #include "wx_includes.hpp"
 #include "wxsymbology.hpp"
 
-class wxPalettePopup : public wxDialog
+#include <wx/popupwin.h>
+
+class wxPalettePopup : public wxPopupTransientWindow
 {
 public:
     wxPalettePopup( ColourPalette *palette, wxWindow* parent, wxWindowID id = wxID_ANY );
@@ -30,16 +59,22 @@ private:
     void LayoutPalette( int rows = 0 );
     void PositionWindow();
     void SetSelectedColour( int colourId );
+    bool IgnoreAsOpeningClick();
 
     void OnPaint( wxPaintEvent &event );
     void OnMouseEvent( wxMouseEvent &event );
     void OnKeyDownEvent( wxKeyEvent &event );
+    void OnCaptureLost( wxMouseCaptureLostEvent &event );
+    void OnDismiss() wxOVERRIDE;
 
     int nrow;
     int ncol;
     int bitmapsize;
     int spacing;
     int selectedColour;
+
+    wxLongLong shownTime;
+    bool ignoreNextButtonUp;
 
     wxColour highlightColour;
 


### PR DESCRIPTION
## Summary
- The colour swatch popup (`wxPalettePopup`, opened from a Key panel colour cell) always appeared centred on the main window instead of at the click point. `wxDialog::Move()`/`SetPosition()` has no effect on its final on-screen position in this environment, under every technique tried (before/after showing, deferred, non-default construction position, `Center()`+`Move()`).
- Rebuilt it on `wxPopupTransientWindow` instead, an override-redirect top-level window (the same kind menus/combo popups use), which honours positioning reliably.
- Since it's no longer modal, `SelectColour()` runs its own nested event loop and captures the mouse for its duration — needed because the popup can overlap sibling panels like the map view, and without exclusive input routing a click there could fall through and register as a real click on the map (e.g. triggering a zoom).
- A gesture flag distinguishes the button-up that ends the click which opened the popup from a genuine dismiss click, regardless of how long that opening click is held.
- Added an explicit border so the popup is visually distinguishable when it overlaps the panel it opened from (same background colour otherwise).

## Before / After 
Some other differences may appear between these images, but the only thing this PR touches is the location of the colour palette as well as adding a thin border so it doesn't melt into the identically coloured side-panel.

**Before:**
<img width="1864" height="1147" alt="before_colour_palette" src="https://github.com/user-attachments/assets/6434a64c-75d0-4a16-84f4-dc0649d5d86c" />

**After:**
<img width="1868" height="1148" alt="after_colour_palette" src="https://github.com/user-attachments/assets/86552a4a-ced0-4691-8958-ccf8c1bca687" />

## Test plan
- [x] Linux (WSL2): click a swatch — opens at the click point, selects on click, dismisses on outside click/Escape
- [x] Windows (Windows Sandbox, MinGW-cross-compiled build): same checks, including a swatch positioned so the popup overlaps the map view, and holding the opening click past the debounce window before releasing

[GSR-999](https://toitutewhenua.atlassian.net/browse/GSR-999)

[GSR-999]: https://toitutewhenua.atlassian.net/browse/GSR-999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ