### PR TITLE
refactor: replace boost::filesystem with std::filesystem in fileutil

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          DEBIAN_FRONTEND=noninteractive sudo apt-get install cmake g++ libboost-dev libboost-math-dev libboost-regex-dev libboost-filesystem-dev python3
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install cmake g++ libboost-dev libboost-math-dev libboost-regex-dev python3
       - name: Build snap command line utilities and run regression tests
         run: python3 build.py release test --no-gui

--- a/BUILD.md
+++ b/BUILD.md
@@ -15,7 +15,7 @@ Only 64-bit builds are supported.
 4. **Boost** — download source from https://www.boost.org/users/download/ and build the
    required components from the Boost root directory:
    ```
-   ./b2 toolset=msvc-14.3 --with-filesystem --with-regex --with-system
+   ./b2 toolset=msvc-14.3 --with-regex --with-system
    ```
    Replace the toolset version to match your Visual Studio installation:
    | Visual Studio | Toolset   |
@@ -106,7 +106,7 @@ MinGW-w64 cross-compiler, without needing Visual Studio at all.
    ./b2 --user-config=$(pwd)/user-config.jam toolset=gcc-13 target-os=windows \
      address-model=64 architecture=x86 link=static runtime-link=static \
      threading=multi variant=release \
-     --with-filesystem --with-regex --with-system --stagedir=stage-mingw -j$(nproc)
+     --with-regex --with-system --stagedir=stage-mingw -j$(nproc)
    ```
    Replace `13` with the major GCC version of your installed
    `g++-mingw-w64-x86-64` (check with `x86_64-w64-mingw32-g++ --version`) - the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,9 @@ elseif(WIN32)
     # so there's no 'mt'/'mt-s' variant choice to make - just select static.
     set(Boost_USE_STATIC_LIBS ON)
 endif()
-find_package(Boost REQUIRED COMPONENTS filesystem regex)
+find_package(Boost REQUIRED COMPONENTS regex)
 # boost::system is header-only since Boost 1.69; newer distros ship no .so for it.
-# FindBoost creates Boost::system as a side-effect of filesystem on older Boost — link
+# FindBoost creates Boost::system as a side-effect of regex on older Boost — link
 # it explicitly only if that target exists, so we don't fail on Ubuntu 24.04+.
 if(TARGET Boost::system)
     set(BOOST_SYSTEM_LIB Boost::system)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,7 +16,6 @@ RUN apt-get install -y \
     libboost-dev \
     libboost-math-dev \
     libboost-regex-dev \
-    libboost-filesystem-dev \
     perl \
     python3 \
     debhelper \

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,6 @@ Build-Depends: debhelper (>= 8.0.0),
     libboost-dev,
     libboost-math-dev,
     libboost-regex-dev,
-    libboost-filesystem-dev,
     libwxgtk3.0-gtk3-dev | libwxgtk3.2-dev,
     python3
 Standards-Version: 3.9.2

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,6 @@ include_directories(
 add_library(snap_link_deps INTERFACE)
 target_include_directories(snap_link_deps INTERFACE ${Boost_INCLUDE_DIRS})
 target_link_libraries(snap_link_deps INTERFACE
-    Boost::filesystem
     Boost::regex
     ${BOOST_SYSTEM_LIB}
     Threads::Threads

--- a/src/snaplib/util/fileutil.cpp
+++ b/src/snaplib/util/fileutil.cpp
@@ -28,7 +28,7 @@
 #define _stat stat
 #include <unistd.h>
 #endif
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 
 #include "util/fileutil.h"
@@ -504,7 +504,7 @@ void dump_filepath( const char *path, FILE *f )
 //
 // This used to double up PATH_SEPARATOR for that marker: '\\' on Windows,
 // '/' on Linux. relative_filename's result also carries PATH_SEPARATOR
-// internally (boost::filesystem::path::string() renders using the platform's
+// internally (std::filesystem::path::string() renders using the platform's
 // native separator). Both make a context string written on one platform
 // unparseable on the other. Worse, it's not even a loud failure: POSIX
 // treats '\\' as a literal filename character, not a separator, so a
@@ -513,7 +513,7 @@ void dump_filepath( const char *path, FILE *f )
 //
 // Fixed by always using '/' here, on both platforms, for the marker and for
 // every separator within each reldir's own content (via portable_path).
-// boost::filesystem::path (used by relative_filename/absolute_filename)
+// std::filesystem::path (used by relative_filename/absolute_filename)
 // accepts '/' as a valid separator on both platforms - unlike '\\' on POSIX.
 const char *context_definition(file_context *context)
 {
@@ -587,9 +587,9 @@ const char *relative_filename( const char *filepath, const char *basedir )
 {
     try
     {
-        boost::filesystem::path fp(filepath);
-        boost::filesystem::path bp(basedir);
-        auto relpath=boost::filesystem::relative( fp, bp );
+        std::filesystem::path fp(filepath);
+        std::filesystem::path bp(basedir);
+        auto relpath=std::filesystem::relative( fp, bp );
         auto relstr=relpath.string();
         return copy_string( relstr.c_str());
     }
@@ -603,9 +603,30 @@ const char *absolute_filename( const char *relname, const char *basedir )
 {
     try
     {
-        boost::filesystem::path rp(relname);
-        boost::filesystem::path bp(basedir);
-        auto relpath=boost::filesystem::absolute( rp, bp );
+        std::filesystem::path rp(relname);
+        std::filesystem::path bp(basedir);
+        // std::filesystem::absolute has no (path, base) overload - it only
+        // resolves against the process's current directory - so resolve
+        // basedir against the current directory ourselves when it isn't
+        // already absolute. std::filesystem::absolute() throws on an empty
+        // path rather than treating it as the current directory, so that
+        // case is handled explicitly too.
+        if( bp.empty() ) {
+            bp = std::filesystem::current_path();
+        }
+        else if( ! bp.is_absolute() ) {
+            bp = std::filesystem::absolute(bp);
+        }
+        std::filesystem::path relpath;
+        if( rp.empty() ) {
+            relpath = bp;
+        }
+        else if( rp.is_absolute() ) {
+            relpath = rp;
+        }
+        else {
+            relpath = bp / rp;
+        }
         auto relstr=relpath.string();
         return copy_string( relstr.c_str());
     }

--- a/src/snaplib/util/fileutil.cpp
+++ b/src/snaplib/util/fileutil.cpp
@@ -589,6 +589,14 @@ const char *relative_filename( const char *filepath, const char *basedir )
     {
         std::filesystem::path fp(filepath);
         std::filesystem::path bp(basedir);
+        // boost::filesystem::relative returns an empty path when either
+        // input is empty; std::filesystem::relative instead returns "."
+        // when the two (both-empty) paths compare equal. context_definition
+        // relies on an empty reldir producing no characters, so that
+        // difference must be preserved here.
+        if( fp.empty() || bp.empty() ) {
+            return copy_string("");
+        }
         auto relpath=std::filesystem::relative( fp, bp );
         auto relstr=relpath.string();
         return copy_string( relstr.c_str());

--- a/src/snaplib/util/fileutil.h
+++ b/src/snaplib/util/fileutil.h
@@ -89,7 +89,22 @@ file_context *set_file_context( file_context *new_context );
 void free_file_contexts();
 const char *context_definition(file_context *context);
 file_context *recreate_context( const  char *context_def );
+/* relative_filename and absolute_filename both operate lexically on the path
+   strings - neither requires filepath, relname, or basedir to exist on disk.
+   Both return a newly allocated string (as per copy_string) that the caller
+   is responsible for freeing. */
+
+/* Expresses filepath relative to basedir - e.g. relative_filename("/a/b/c","/a/b")
+   returns "c". Returns "." if the two paths resolve to the same location. Falls
+   back to returning a copy of filepath unchanged if the paths can't be compared
+   (e.g. on Windows, when they're on different drives). */
 const char *relative_filename( const char *filepath, const char *basedir );
+
+/* Resolves relname to an absolute path. If relname is already absolute, it is
+   returned unchanged; otherwise it is composed onto basedir. basedir is
+   resolved against the current working directory first if it is itself
+   relative (including empty). Falls back to returning a copy of relname
+   unchanged if resolution fails. */
 const char *absolute_filename( const char *relname, const char *basedir );
 
 /* Returns path with every PATH_SEPARATOR replaced by '/', for writing a path


### PR DESCRIPTION
C++17 is already required and covers the path operations `fileutil.cpp` used from `boost::filesystem`. Drop the now-unneeded `filesystem` component from the `Boost` build and packaging dependencies.

`std::filesystem::absolute` lacks `boost`'s `(path, base)` overload, so `absolute_filename` resolves `basedir` itself first when it isn't already absolute. It also throws on an empty path rather than treating it as the current directory, unlike `boost`, so that case is handled explicitly.

Verified the new implementation matches `boost`'s output across a wide matrix of inputs, and confirmed the full project (including GUI targets) builds and links cleanly against `Boost 1.90` in three configurations: `Linux/GCC` against the system package, `MinGW` cross-compile against the existing `Boost 1.78`, and `MinGW` cross-compile against a freshly cross-built `Boost 1.90`.