### PR TITLE
fix: write the system PATH registry value as REG_EXPAND_SZ, not REG_SZ

### DIFF
--- a/src/resources/snap_setup.js
+++ b/src/resources/snap_setup.js
@@ -56,5 +56,5 @@ if (snappath !== "") {
     }
 
     // Write the key
-    sh.RegWrite(key, path, "REG_SZ");
+    sh.RegWrite(key, path, "REG_EXPAND_SZ");
 }


### PR DESCRIPTION
## Summary

`snap_setup.js` (the NSIS install-time script that prepends the SNAP install directory to the system PATH) wrote the `Path` registry value back with type `REG_SZ` instead of `REG_EXPAND_SZ`. This downgrades the value's type, so Windows stops expanding `%SystemRoot%`-style tokens when building new environment blocks. PATH ends up containing literal, non-existent entries like `%SystemRoot%\system32`.

`FindProgram()` in `snap_manager` (`src/snap_manager/snap_scriptenv.cpp`) walks PATH directories directly with no environment-variable expansion, so it can't resolve `cmd.exe` or the configured editor through a corrupted entry. This surfaces in `snap_manager` as:

- "The command shell is not defined - DOS window not available"
- "The editor is not defined or available - files cannot be edited"

The same `REG_SZ` write is present in the original 2016 `snap_setup.vbs` this script was ported from, so this isn't a regression from the CMake/NSIS migration — it's a pre-existing defect carried forward unchanged.

## Fix

`src/resources/snap_setup.js`: `sh.RegWrite(key, path, "REG_SZ")` → `sh.RegWrite(key, path, "REG_EXPAND_SZ")`.

The rewrite preserves the existing PATH content and only corrects the registry value's type, so installing a build with this fix should also repair a machine whose PATH was already corrupted by a prior install.

## Test plan

- [x] Built `windows-mingw-release-gui` package (`snap-3.0.0-win64.exe`) with the fix
- [x] Installed in a fresh Windows Sandbox — confirmed `PATH` shows expanded paths (e.g. `C:\Windows\system32`, not `%SystemRoot%\system32`) and the Tools → DOS window menu item is no longer greyed out
- [x] Installed on a previously affected real Windows machine — confirmed working