### PR TITLE
fix: extract load_version_field helper in LINZDEF parser

### DIFF
--- a/src/snaplib/dbl4/dbl4_utl_lnzdef.cpp
+++ b/src/snaplib/dbl4/dbl4_utl_lnzdef.cpp
@@ -416,6 +416,44 @@ static StatusType load_date( hBinSrc binsrc, long offset, DateTimeType *date )
 
 
 /*************************************************************************
+** Function name: load_version_field
+**//**
+**    Load a version identifier (VERSION, VERSION_NUMBER, VERSION_START,
+**    or VERSION_END) into a fixed-size buffer. VERSION_NUMBER (version
+**    1/2) and VERSION (version 3) have always accepted strings longer
+**    than VERSIONLEN by silently truncating them, so rejectOverlength
+**    must be false for those two to preserve that behaviour. Only
+**    VERSION_START/VERSION_END have always rejected them.
+**
+**  \param binsrc              The binary source object
+**  \param dest                The destination buffer (VERSIONLEN+1 bytes)
+**  \param rejectOverlength     If true, reject strings longer than
+**                             VERSIONLEN instead of truncating them
+**
+**  \return                    The return status
+**
+**************************************************************************
+*/
+
+static StatusType load_version_field( const hBinSrc binsrc, Version dest, const bool rejectOverlength )
+{
+    char *data=0;
+    const StatusType sts = utlBinSrcLoadString( binsrc, BINSRC_CONTINUE, &data );
+    if( sts != STS_OK ) {
+        RETURN_STATUS( sts );
+    }
+    if( rejectOverlength && strlen(data) > VERSIONLEN ) {
+        utlFree(data);
+        RETURN_STATUS( STS_INVALID_DATA );
+    }
+    strncpy( dest, data, VERSIONLEN );
+    dest[VERSIONLEN] = 0;
+    utlFree(data);
+    return STS_OK;
+}
+
+
+/*************************************************************************
 ** Function name: load_component
 **//**
 **    Creates and loads a deformation component
@@ -781,18 +819,10 @@ static StatusType load_sequence( int version, hBinSrc binsrc, hDefSeq *pseq )
 
     if( sts == STS_OK && version >= 3 )
     {
-        char *data=0;
-        sts = utlBinSrcLoadString( binsrc, BINSRC_CONTINUE, &data );
-        if( sts == STS_OK && strlen(data) > VERSIONLEN ) sts = STS_INVALID_DATA;
-        strncpy( seq->startver, data, VERSIONLEN );
-        seq->endver[VERSIONLEN]=0;
-        utlFree(data);
-        data=0;
-        if( sts == STS_OK ) sts = utlBinSrcLoadString( binsrc, BINSRC_CONTINUE, &data );
-        if( sts == STS_OK && strlen(data) > VERSIONLEN ) sts = STS_INVALID_DATA;
-        strncpy( seq->endver, data, VERSIONLEN );
-        seq->endver[VERSIONLEN]=0;
-        utlFree(data);
+        sts = load_version_field( binsrc, seq->startver, true );
+        if( sts == STS_OK ) {
+            sts = load_version_field( binsrc, seq->endver, true );
+        }
     }
 
     if( sts == STS_OK ) sts = utlBinSrcLoad2( binsrc, BINSRC_CONTINUE, 1, &ncomponents );
@@ -1190,7 +1220,6 @@ static StatusType create_def_mod( hDefMod* pdef, hBinSrc binsrc)
     INT2 nver=0;
     int idseq;
     hDefVer ver=0;
-    char *data;
 
     (*pdef) = NULL;
 
@@ -1218,17 +1247,12 @@ static StatusType create_def_mod( hDefMod* pdef, hBinSrc binsrc)
     ver=0;
     if( version < 3 ) { sts=create_def_ver( &ver ); def->firstver=ver; }
     if( sts == STS_OK ) sts = utlBinSrcLoadString( binsrc, indexloc, &(def->name) );
-    if( sts == STS_OK && version < 3 ) 
-    { 
-        sts = utlBinSrcLoadString( binsrc, BINSRC_CONTINUE, &data );
-        if( sts == STS_OK )
-        {
-            if( data[0] )
-            {
-                strncpy( ver->version, data, VERSIONLEN );
-                ver->version[VERSIONLEN]=0;
-            }
-            utlFree(data);
+    if( sts == STS_OK && version < 3 )
+    {
+        Version tmpver;
+        sts = load_version_field( binsrc, tmpver, false );
+        if( sts == STS_OK && tmpver[0] ) {
+            strcpy( ver->version, tmpver );
         }
     }
     if( sts == STS_OK ) sts = utlBinSrcLoadString( binsrc, BINSRC_CONTINUE, &(def->crdsyscode) );
@@ -1256,13 +1280,7 @@ static StatusType create_def_mod( hDefMod* pdef, hBinSrc binsrc)
             *pver=ver;
             pver=&(ver->nextver);
 
-            sts = utlBinSrcLoadString( binsrc, BINSRC_CONTINUE, &data );
-            if( sts == STS_OK )
-            {
-                strncpy( ver->version, data, VERSIONLEN );
-                ver->version[VERSIONLEN]=0;
-                utlFree(data);
-            }
+            sts = load_version_field( binsrc, ver->version, false );
             if( sts == STS_OK ) sts = load_date( binsrc, BINSRC_CONTINUE, &(ver->versiondate) );
             if( sts == STS_OK ) sts = utlBinSrcLoadString( binsrc, BINSRC_CONTINUE, &(ver->description) );
         }


### PR DESCRIPTION
## Summary

`dbl4_utl_lnzdef.cpp` had four separate call sites that each duplicated
the same "load a string, copy it into a `VERSIONLEN`-sized buffer"
logic, and the duplication had drifted:

- One site null-terminated `seq->endver` immediately after loading
  `seq->startver`, instead of terminating `startver` itself. Harmless
  in practice (the buffer was already zeroed by its default
  initialization), but clearly not what was intended.
- Two of the four sites (`VERSION_NUMBER` in v1/v2, `VERSION` in v3)
  never validated the loaded string's length before truncating it,
  while the other two (`VERSION_START`/`VERSION_END`) did.
- If the underlying read failed, the old code still called `strncpy`
  on a NULL pointer regardless of status.

Replaced all four with a single `load_version_field` helper, so each
destination buffer is null-terminated correctly by construction. It
takes a `rejectOverlength` flag so each call site keeps its
pre-existing validation behaviour exactly: `VERSION_START`/
`VERSION_END` still reject overlong values as before, and
`VERSION_NUMBER`/`VERSION` still silently truncate them, since real
files may already depend on that leniency — this fix is about
removing the duplication that caused the copy-paste bug, not changing
what input is accepted.

## Test plan

- [x] Compiles cleanly with `-Wall` (verified locally)
- [x] Full regression suite (`testall.pl -r`) passes, including the `snap`
      suite's `testdef3` test, which loads a real v1 LINZDEF file
- [x] A `VERSION_NUMBER` over 8 characters still loads and is truncated to
      8, not rejected (built via `linzdeformationmodel.py`, verified via a
      small harness calling `utlCreateLinzDef`/`utlLinzDefTitle` directly)
- [x] A `VERSION_START` over 8 characters is still rejected with
      `STS_INVALID_DATA`, verified the same way