### PR TITLE
fix: make snap's exit code reflect whether the run actually succeeded

### DIFF
--- a/src/snap/snapmain.cpp
+++ b/src/snap/snapmain.cpp
@@ -46,6 +46,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
+#include <exception>
 #include "util/snapctype.h"
 
 #define _SNAPMAIN_C
@@ -110,6 +111,7 @@ static void write_filelist_csv();
 static int force_zero_inverse=0;
 
 int snap_main( int argc, char *argv[] )
+try
 {
 
     int show_iterations;
@@ -717,6 +719,20 @@ int snap_main( int argc, char *argv[] )
         xprintf( "\nWARNING: Adjustment has not converged - results may be misleading\n" );
         xprintf( "Final iteration maximum adjustment is %.4lf.\n",last_iteration_max_adjustment );
     }
+    return get_error_count() > 0 ? DEFAULT_RETURN_STATUS : OK;
+}
+catch( const std::exception &e )
+{
+    char errmess[256];
+    snprintf( errmess, sizeof(errmess), "Unexpected internal error: %s", e.what() );
+    handle_error( INVALID_DATA, errmess, NO_MESSAGE );
+    close_output_files(0,0);
+    return DEFAULT_RETURN_STATUS;
+}
+catch( ... )
+{
+    handle_error( INVALID_DATA, "Unexpected internal error of unknown type", NO_MESSAGE );
+    close_output_files(0,0);
     return DEFAULT_RETURN_STATUS;
 }
 

--- a/src/snap_manager/config/snapscript/adjust.inc
+++ b/src/snap_manager/config/snapscript/adjust.inc
@@ -9,14 +9,24 @@ function RunAdjustment()
    DeleteFile(FindJobFile("lst"))
    DeleteFile(FindJobFile("err"))
    
-   debugrun("$snap_path/snapadjust",$job_file)
-   $error_file = FindJobFile("err")
-   if $error_file then
-      if Ask("SNAP has reported errors with this job\r\nView the error file","SNAP errors") then
-         start($_editor,$error_file)
+   # snapadjust's exit status is 0 for a genuinely clean run and non-zero
+   # otherwise - including runs that only logged informational notices, which
+   # still keep their .err file (with that informational content) but are not
+   # themselves a problem worth interrupting the user about here.
+   $exit_status = debugrun("$snap_path/snapadjust",$job_file)
+   if $exit_status != "0" then
+      $error_file = FindJobFile("err")
+      if $error_file then
+         if Ask("SNAP has reported errors with this job\r\nView the error file","SNAP errors") then
+            start($_editor,$error_file)
+         endif
+      else
+         if Ask("SNAP did not complete successfully (exit status $exit_status), though it reported no specific errors.\r\nResults may be incomplete or invalid.\r\n\r\nView the listing file","SNAP failed") then
+            start($_editor,FindJobFile("lst"))
+         endif
       endif
    endif
-end_function   
+end_function
  
 #######################################################################
 # Function to plot an adjustment


### PR DESCRIPTION
## Summary

`snap`'s exit code was always the same fixed value regardless of outcome, so
nothing checking it - scripts, `snap_manager` - could tell a clean run from
one that logged real errors.

- `snap_main` now returns 0 only when no warning-or-worse error was
  reported, instead of always returning the same constant.
- `snap_main` is wrapped in a function-try-block. An uncaught C++ exception
  previously aborted the process directly, skipping `close_output_files`
  entirely, so no message ever reached the `.err` file. A caught exception
  now reports via `handle_error` and shuts down normally instead.
- `snap_manager`'s `RunAdjustment` now checks the exit status first, and
  only offers to view the `.err`/`.lst` file when the run actually failed.
  A run that only logged an informational notice no longer triggers a
  false "SNAP has reported errors" prompt.

This is likely preparatory groundwork rather than a full fix, since a
meaningless exit code was only one contributing gap. Miriam has seen jobs
fail without any meaningful error information; the root cause of those
failures is still being investigated.

## Test plan

- [x] Compiles cleanly
- [x] Full regression suite (`testall.pl -r`) passes with zero reference
      file changes needed
- [x] Verified directly: a genuinely clean run now exits 0 with no `.err`
      file (`testdef3`)
- [x] Verified directly: a run with only an informational notice (no real
      error) still exits 0 and keeps its `.err` file with that content
      intact (`test1z`)

## Notes

- `snap_manager`'s updated `RunAdjustment` dialog behaviour has not
      been click-tested in the GUI

[GSR-1011](https://toitutewhenua.atlassian.net/browse/GSR-1011)

[GSR-1011]: https://toitutewhenua.atlassian.net/browse/GSR-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ