### PR TITLE
fix: stop recode file crashing with a NULL codefrom

### DIFF
--- a/src/snaplib/snapdata/stnrecode.cpp
+++ b/src/snaplib/snapdata/stnrecode.cpp
@@ -443,6 +443,13 @@ int read_station_recode_definition( stn_recode_map *stt, char *def, char *basefi
     }
     else if ( _stricmp(field,"file") == 0 )
     {
+        // "recode file <recodefile>" is a distinct grammar from the other
+        // two forms below, and shares none of their optional uncertainty or
+        // date-range clauses etc. - the recode file's own columns are all it
+        // supports. read_station_recode_file has already applied every
+        // recode from the file by the time it returns, so this branch returns
+        // immediately rather than falling into logic that assumes codefrom
+        // and codeto are set.
         char *filename=next_field(&def);
         int sts;
         if( ! filename )
@@ -459,6 +466,11 @@ int read_station_recode_definition( stn_recode_map *stt, char *def, char *basefi
                 ok=0;
             }
         }
+        if( ! ok )
+        {
+            handle_error(INVALID_DATA,"Error reading station recoding",msg);
+        }
+        return ok ? OK : INVALID_DATA;
     }
     else if ( _stricmp(field,"suffix") == 0 )
     {


### PR DESCRIPTION
## Summary

Every use of `recode file <recodefile>` crashed SNAP unconditionally,
regardless of the recode file's own content, leaving an empty `.err` file
behind - matching a user report of the feature being "unclear... doesn't
work... error file empty". Reported by @mermy 

`read_station_recode_definition` (`stnrecode.cpp:410`) handles three
distinct recode grammars in one function: `file`, `suffix`, and inline
`<code> to <code>`. The `file` branch fully delegates to
`read_station_recode_file`, which already applies every recode from the
CSV itself - but the branch never returned afterward, so execution fell
through into ~200 lines of optional uncertainty/date-range parsing that
only apply to the other two grammars (confirmed: the CSV format's own
columns have no uncertainty equivalent at all), ending in a call to
`add_stn_recode_to_map_err` with `codefrom`/`codeto` still `NULL` (never
set on this branch). `_stricmp(NULL, ...)` segfaults immediately.

The crash happening before `close_output_files()` can run is why the
`.err` file was empty - same underlying mechanism as
fix/snap-exit-code-error-reporting, just unreachable by that fix since a
segfault isn't a C++ exception.

Fix: the `file` branch now returns immediately after handling itself,
since it never shared any of the fall-through logic to begin with.

## Test plan

- [x] Reproduced the crash directly (hand-built minimal `.snp`/`.crd`/
      `.dat`/recode-CSV, release build segfaults immediately, both `.err`
      and `.lst` come out as 0 bytes)
- [x] Root-caused with AddressSanitizer (no `gdb` available, no root to
      install it) - pointed directly at the NULL dereference
- [x] Confirmed fixed: same reproduction now completes normally, produces
      a correct `.lst` with the recode actually applied, no `.err`
- [x] Full regression suite (`testall.pl -r`) passes unchanged

[GSR-1011](https://toitutewhenua.atlassian.net/browse/GSR-1011)

[GSR-1011]: https://toitutewhenua.atlassian.net/browse/GSR-1011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ